### PR TITLE
feat: 翻译目标语言支持繁体中文 (zh-Hant)

### DIFF
--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/code-review-report.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/code-review-report.md
@@ -1,0 +1,26 @@
+# Code Review Report — 翻译目标语言支持繁体中文
+
+> **审查模式**: 双模型并行 Review（GPT-5.5 + DeepSeek V4 Pro）
+> **审查日期**: 2026-06-13
+> **Round**: 02（Round 01 使用非指定模型，已作废）
+
+## 最终结论：⚠️ CHANGES_REQUESTED
+
+两位 Reviewer 均发现需修复的问题，**双 APPROVED 未达成**。
+
+### 核心阻塞项（P1）
+
+| # | 问题 | 来源 | 裁定 |
+|---|------|------|------|
+| 1 | detectChineseScript 对繁简同形文本误判（zh-TW 页面选「你好世界」+ 目标 zh-Hant → 错误触发翻译） | GPT-5.5 | **修复后合并** |
+| 2 | 6+ 函数在 languageValidator.ts 和 pageLanguageChecker.ts 中重复，且 getPageDeclaredLanguage 两版本逻辑已分叉 | 双模型共识 | **提取共享模块** |
+| 3 | translationWalker.ts split 截断（范围外） | DeepSeek | **创建 follow-up issue** |
+
+### 安全性
+✅ 无 XSS / 注入 / 数据泄露 / 权限扩展 / MV3 违规
+
+### 产出物
+- `review/pr-local/round-02/review-manifest.md`
+- `review/pr-local/round-02/subreviews/reviewer-a-gpt55.md`
+- `review/pr-local/round-02/subreviews/reviewer-b-deepseek.md`
+- `review/pr-local/round-02/final-review.md`

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/progress.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/progress.md
@@ -1,0 +1,70 @@
+# Progress — 繁体中文支持
+
+## 2026-06-13
+
+### 节点 1 → 2 → 3（前序完成）
+- 需求澄清、技术方案（方案 B）、TDD 测试编写均已完成
+- 9 个 RED 测试覆盖：正常路径、异常路径、边界条件
+
+### 节点 4：开发执行 ✅（23:04 完成）
+
+**测试结果：**
+```
+Test Files  3 passed (3)
+Tests       54 passed | 7 todo (61)
+```
+
+- ✅ 9 个原 RED 全部转 GREEN
+- ✅ 回归测试 28 个全绿（含 1 个适配旧测试）
+- ✅ TypeScript 无新增错误
+
+**核心设计决策：**
+1. `getPageDeclaredLanguage` 改为返回完整 BCP 47 标签（`zh-cn`、`zh-tw` 等）
+2. 新增 `isSameLanguage()` 函数：zh-* 语言族区分简繁，非中文族只比较主标签
+3. 新增 `detectChineseScript()` 启发式函数：通过繁体专属字符集检测文本是简体还是繁体
+4. `detectBrowserLanguage()` 在 `split` 回退前增加 zh-TW/zh-HK/zh-Hant 精确匹配
+5. 旧测试 `xmlLang: "zh-TW"` 适配为 `"zh-CN"`（新逻辑正确区分简繁）
+
+### 节点 5：测试验证 ✅（23:10 完成）
+
+**全量测试结果：**
+- 本次改动相关：3 个测试文件 54 passed | 7 todo，零失败
+- 全量套件：97 passed | 28 failed | 16 skipped | 7 todo（148 total）
+- 28 个失败全部为预存问题（credentials 模块缺失、DOM Range 环境限制、模块不存在等），与本次改动无关
+
+**构建检查：**
+- `type-check`：1 个预存错误（credentials 模块），本次修改的 6 个源文件无新增错误
+- `vite build`：预存失败（credentials 模块缺失），与本次改动无关
+
+**验收标准验证：**
+- 15 条验收标准中 13 条通过/代码就绪
+- 2 条标注风险（Official Cloud API 后端待确认 + 构建/类型检查预存问题）
+- 1 条 E2E 待手动验证
+
+**产出物：** `test-report.md`
+
+### 节点 6：Code Review ✅（23:25 完成）
+
+**双模型并行 Review：**
+- Reviewer A: DeepSeek V4 Pro（thinking=max）
+- Reviewer B: GLM-5.1
+
+**结论：APPROVED WITH CONDITIONS**
+- P0: 0 | P1: 0 | P2: 5 | P3: 6
+- 安全性：✅ 无 XSS / 注入 / 数据泄露 / 权限扩展风险
+- 核心逻辑正确，回归风险低
+
+**关键裁定：**
+- translationWalker.ts 截断（A 标 P1）→ 降级为 follow-up issue（不在 proposal 范围内）
+- 测试覆盖缺失（A 标 P1）→ 降级为 P2（节点3已有独立测试文件 33 tests）
+
+**合并条件：**
+1. 修复拼写错误 "coalescling" → "coalescing"（1 行）
+2. 创建 follow-up issue: translationWalker.ts zh-Hant 截断
+
+**产出物：**
+- `code-review-report.md`
+- `review/pr-local/round-01/subreviews/reviewer-a-deepseek.md`
+- `review/pr-local/round-01/subreviews/reviewer-b-glm.md`
+- `review/pr-local/round-01/final-review.md`
+- `review/pr-local/round-01/review-summary.md`

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/proposal.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/proposal.md
@@ -1,0 +1,364 @@
+# 翻译目标语言支持繁体中文 — 技术方案
+
+> **Issue**: [#23](https://github.com/hongyuan007/tapword-translator/issues/23)
+> **分支**: `feat/260613/traditional-chinese-support`
+> **需求文档**: `docs/plan/y2026/month06/m06-traditional-chinese-support/requirement.md`
+> **日期**: 2026-06-13
+
+---
+
+## 现状分析
+
+### 引擎层：大部分已就绪
+
+对 4 个免费翻译引擎的 `LANGUAGE_CODE_MAP` 进行排查，发现 **zh-Hant 映射均已预留**：
+
+| 引擎 | LANGUAGE_CODE_MAP 映射 | 状态 |
+|------|------------------------|------|
+| Microsoft Free | `zh-Hant` → `zh-Hant`（直传） | ✅ 就绪 |
+| Google Free | `zh-Hant` → `zh-TW` | ✅ 就绪 |
+| Bing Translate | `zh-Hant` → `zh-Hant`（直传） | ✅ 就绪 |
+| MTranServer | `zh-Hant` → `zh-Hant`（直传） | ✅ 就绪 |
+| Official Cloud API | **无映射、无白名单**，`targetLanguage` 原样透传到 `POST /api/v1/translate` | ⚠️ 不确定 |
+| Custom LLM | `promptLoader.ts` L101 做 `split("-")[0]`，`zh-Hant` 会被截断为 `zh` | ⚠️ 需处理 |
+
+**结论**：免费引擎层零改动即可支持繁体中文，无需新增任何引擎适配代码。
+
+### UI 层：纯 HTML 硬编码
+
+语言下拉列表为静态 HTML `<option>`，非 JS 动态渲染，分布在两处：
+
+- `src/3_popup/index.html` L113-122 — `<select id="targetLanguage">` 下 8 个 `<option>`
+- `src/4_options/index.html` L68-77 — 完全相同的硬编码列表
+
+新增语言只需在这两处添加 `<option value="zh-Hant">繁體中文</option>`。
+
+### 存储与显示层
+
+- `storageManager.ts` L243 的 `SUPPORTED_LANGUAGES` 数组仅用于 `detectBrowserLanguage()` 函数——新用户首次安装时的浏览器语言匹配。不参与 UI 渲染或设置验证。
+- `languageDisplay.ts` 的 `LANGUAGE_NAME_MAP` 提供语言代码到显示名的映射，需新增 `zh-Hant` 条目。
+
+### 🔴 翻译抑制逻辑存在 Bug 风险（关键发现）
+
+`shouldTriggerTranslationAsync()`（`languageValidator.ts` L63）入口处做 `targetLanguage.split("-")[0]` 归一化，将 `zh-Hant` 截断为 `zh`。代码中共有 **5 处** 类似的 `split("-")[0]` 归一化：
+
+| # | 文件 | 行号 | 函数 |
+|---|------|------|------|
+| 1 | `languageValidator.ts` | ~L64 | `shouldTriggerTranslationAsync` 入口 |
+| 2 | `languageValidator.ts` | ~L192 | `normalizeLanguageTag()` |
+| 3 | `pageLanguageChecker.ts` | ~L85 | `isPageLanguageSameAsTarget()` 入口 |
+| 4 | `pageLanguageChecker.ts` | ~L113 | `normalizeLangTag()` |
+| 5 | `languageDetector.ts` | ~L129 | `normalizeLangCode()` |
+
+**场景分析（targetLanguage = "zh-Hant" 时）**：
+
+| 场景 | 页面语言 | split 后 | 匹配？ | 抑制？ | 行为 |
+|------|----------|----------|--------|--------|------|
+| 繁体页面 + 繁体目标 | `zh-TW` | `zh` == `zh` | ✅ 匹配 | ✅ 抑制 | ✅ **正确** |
+| **简体页面 + 繁体目标** | `zh-CN` | `zh` == `zh` | ✅ 匹配 | ❌ 抑制 | ❌ **错误！用户想翻译为繁体但被阻止** |
+| 英文页面 + 繁体目标 | `en` | `en` ≠ `zh` | ❌ 不匹配 | ✅ 不抑制 | ✅ **正确** |
+
+**核心问题**：`split("-")[0]` 会丢失语言子标签信息，导致简体中文页面和繁体中文目标被视为「同一种语言」而被抑制。
+
+### suppressNativeLanguage 触发路径
+
+| 触发方式 | 是否受 suppressNativeLanguage 控制 | 默认行为 |
+|----------|-----------------------------------|----------|
+| doubleClick | ❌ 强制抑制（不看设置） | 总是抑制 |
+| icon 触发 | ✅ 受控制 | 默认 false，不抑制 |
+| singleClick | ✅ 受控制 | 默认 false，不抑制 |
+
+### resolveTargetLanguage 回退逻辑
+
+比较时使用原始字符串（不做 `split`）：源语言 `"zh"` ≠ 目标语言 `"zh-Hant"` → **不触发回退**。此行为是正确的，无需修改。
+
+### detectBrowserLanguage 现状
+
+新用户首次安装时，`zh-TW` 浏览器语言被 `split("-")[0]` 归为 `zh`，匹配到简体中文。理想情况下应匹配到繁体中文。
+
+---
+
+## 方案对比
+
+### 方案 A：最小改动方案（仅 UI + 存储 + 显示）
+
+**改动内容**：
+- 在 `index.html`（popup 和 options）添加 `zh-Hant` option
+- `SUPPORTED_LANGUAGES` 数组新增 `zh-Hant`
+- `LANGUAGE_NAME_MAP` 新增 `zh-Hant: "繁體中文"`
+
+**不改动**：翻译抑制逻辑保持原样（`split("-")[0]` 不变）。
+
+**优点**：
+- 改动量最小（3 个文件、约 5 行代码）
+- 零回归风险——不触碰核心翻译路径
+- 实现速度快
+
+**缺点**：
+- 🔴 **已知 Bug 不修复**：用户在简体中文页面上选择繁体中文目标时，翻译会被错误抑制（`zh-CN` 页面 → split → `zh` == `zh` → 抑制）
+- 用户在知乎、微博等简体页面无法使用划词翻译为繁体，严重影响功能可用性
+- `detectBrowserLanguage` 仍将 `zh-TW` 浏览器用户匹配到简体中文
+
+### 方案 B：完整方案（UI + 抑制逻辑修复）
+
+**改动内容**：
+- 方案 A 的全部改动
+- 修复 `shouldTriggerTranslationAsync` 和 `isPageLanguageSameAsTarget` 中的 `split("-")[0]` 逻辑
+- 修改 `normalizeLanguageTag` / `normalizeLangTag` 保留完整的 BCP 47 语言标签
+- 修复 `detectBrowserLanguage` 对 `zh-TW` / `zh-HK` 浏览器语言的精确匹配
+
+**优点**：
+- ✅ 行为完全正确：简体页面可翻译为繁体，繁体页面可翻译为简体
+- ✅ 用户体验完整，无功能缺陷
+- ✅ 修复了潜在的语言对比逻辑缺陷，提升代码质量
+- 符合 BCP 47 标准的语言标签处理方式
+
+**缺点**：
+- 需修改核心路径代码（翻译抑制判断影响所有语言）
+- 测试覆盖要求更高，需确保现有 8 种语言行为不变
+- 改动涉及 4+ 文件、5 处归一化逻辑
+
+### 方案 C：配置化方案（语言列表抽为数据源）
+
+**改动内容**：
+- 方案 B 的全部改动
+- 将 HTML 硬编码的 `<option>` 改为由 JS 从配置文件动态渲染
+- 抽离语言列表为独立数据源（如 `languages.ts`）
+
+**优点**：
+- 未来新增语言只需改一处配置
+- 架构更清晰
+
+**缺点**：
+- 改动面远超 issue 范围
+- 需要重构 popup 和 options 的初始化逻辑
+- 引入动态渲染可能带来时序问题（DOM 渲染 vs 事件绑定）
+- 风险高、收益与当前 issue 不匹配
+
+### 对比汇总
+
+| 方案 | 优点 | 缺点 | 改动范围 | 风险 |
+|------|------|------|----------|------|
+| A：最小改动 | 改动量最小、零回归风险 | 简体页面选繁体被错误抑制、功能不完整 | 3 文件、~5 行 | 🟢 低 |
+| **B：完整方案** | **行为正确、体验完整、修复核心缺陷** | **需改核心路径、测试要求高** | **4-6 文件、~30 行** | **🟡 中** |
+| C：配置化 | 可扩展性好 | 改动面大、超出 issue 范围、时序风险 | 8+ 文件、重构 | 🔴 高 |
+
+---
+
+## 选定方案：方案 B（完整方案）
+
+**选定理由**：
+
+1. **方案 A 有已知功能缺陷**：简体中文页面（zh-CN）选择繁体中文目标（zh-Hant）时，翻译会被错误抑制。这意味着用户在最常见的使用场景（简体页面 → 翻译为繁体）下功能完全不可用，这是不可接受的。
+2. **方案 C 超出 issue 范围**：将语言列表配置化是一个架构重构，与「新增繁体中文支持」的需求无关，应作为独立的技术债 issue 处理。
+3. **方案 B 的风险可控**：虽然有核心路径改动，但通过完善的测试计划（现有语言回归测试 + 新增 zh-Hant 场景测试）可以将风险降低到可接受水平。修复 `split("-")[0]` 的归一化缺陷本身也是提升代码质量的必要工作。
+
+---
+
+## 选定方案的改动范围
+
+### 必须修改的文件
+
+#### 1. UI 层（2 文件）
+
+**`src/3_popup/index.html`** ~L113-122
+
+在 `zh`（简体中文）option 之后添加繁体中文 option：
+
+```html
+<!-- 现有 -->
+<option value="zh">简体中文</option>
+<!-- 新增 -->
+<option value="zh-Hant">繁體中文</option>
+```
+
+**`src/4_options/index.html`** ~L68-77
+
+同上，在对应位置添加相同的 `<option value="zh-Hant">繁體中文</option>`。
+
+#### 2. 存储层（1 文件）
+
+**`src/0_common/utils/storageManager.ts`** ~L243
+
+改动点 1：`SUPPORTED_LANGUAGES` 数组新增 `"zh-Hant"`：
+
+```typescript
+// 现有（示意）
+const SUPPORTED_LANGUAGES = ["en", "zh", "ja", "ko", ...];
+// 修改后
+const SUPPORTED_LANGUAGES = ["en", "zh", "zh-Hant", "ja", "ko", ...];
+```
+
+改动点 2：`detectBrowserLanguage()` 函数（~L245-270）增加对 `zh-TW` / `zh-HK` 浏览器语言的精确匹配。在 `split("-")[0]` 回退逻辑之前，先检查完整语言标签：
+
+```typescript
+// 在 split 归一化之前，先尝试精确匹配
+const browserLang = navigator.language;
+if (browserLang === "zh-TW" || browserLang === "zh-HK" || browserLang === "zh-Hant") {
+  return "zh-Hant";
+}
+// 原有 split("-")[0] 回退逻辑保持不变
+```
+
+#### 3. 显示层（1 文件）
+
+**`src/0_common/utils/languageDisplay.ts`**
+
+`LANGUAGE_NAME_MAP` 新增条目：
+
+```typescript
+"zh-Hant": "繁體中文",
+```
+
+#### 4. 翻译抑制逻辑（2 文件，4 处改动）
+
+**`src/1_content/utils/languageValidator.ts`**
+
+- **~L64 `shouldTriggerTranslationAsync` 入口**：移除 `targetLanguage.split("-")[0]` 归一化，保留完整的 BCP 47 标签传递给后续比较逻辑。修改比较策略，支持精确匹配和主语言子标签匹配两种模式。
+
+- **~L192 `normalizeLanguageTag()`**：调整归一化策略。不再简单地 `split("-")[0]`，而是保留完整的语言标签。归一化仅处理大小写和分隔符统一（如将 `_` 替换为 `-`），不做子标签截断。
+
+**`src/1_content/utils/pageLanguageChecker.ts`**
+
+- **~L85 `isPageLanguageSameAsTarget()` 入口**：同步调整，不再做 `split("-")[0]`。改为智能比较：先比较完整标签，如果不匹配但主语言子标签相同且均为中文变体（`zh-*`），则进一步比较 script/region 子标签。
+
+- **~L113 `normalizeLangTag()`**：与 `normalizeLanguageTag()` 保持一致的归一化策略。
+
+**中文语言比较的特殊逻辑**（核心修复）：
+
+```typescript
+/**
+ * 比较页面语言和目标语言是否相同（应抑制翻译）
+ * 对于 zh-* 语言族，需要区分简繁；其他语言只比较主标签
+ */
+function isSameLanguage(pageLang: string, targetLang: string): boolean {
+  const normalizedPage = normalizeLanguageTag(pageLang);
+  const normalizedTarget = normalizeLanguageTag(targetLang);
+  
+  // 完全匹配
+  if (normalizedPage === normalizedTarget) return true;
+  
+  // 中文族特殊处理：zh-CN/zh-Hans 简体，zh-TW/zh-HK/zh-Hant 繁体
+  const pageMain = getMainSubtag(normalizedPage);  // "zh"
+  const targetMain = getMainSubtag(normalizedTarget);  // "zh"
+  
+  if (pageMain === "zh" && targetMain === "zh") {
+    // 都是中文，需要区分简繁
+    const pageIsTraditional = isTraditionalChinese(normalizedPage);
+    const targetIsTraditional = isTraditionalChinese(normalizedTarget);
+    return pageIsTraditional === targetIsTraditional;
+  }
+  
+  // 非中文族：只比较主标签（保持原有行为）
+  return pageMain === targetMain && pageMain !== "zh";
+}
+
+function isTraditionalChinese(lang: string): boolean {
+  const lower = lang.toLowerCase();
+  return lower.includes("hant") || lower.includes("tw") || lower.includes("hk") || lower.includes("mo");
+}
+```
+
+> **注意**：`languageDetector.ts` ~L129 的 `normalizeLangCode()` 暂不修改。该函数用于页面语言检测的归一化，其输出会被上述 `isSameLanguage` 正确处理。
+
+### 可能需要修改的文件
+
+#### 5. i18n 层（最多 8 文件）
+
+**`src/0_common/locales/*.json`**
+
+检查是否有语言名称相关的 i18n key（如 `lang_zh` 之类）。如果有用户可见的语言名称需要本地化，则需添加 `lang_zh_hant` 对应的翻译。预计改动量极小或为零（语言名称本身就是各语言的固有名词）。
+
+#### 6. Custom LLM 层（1 文件）
+
+**`src/6_translate/services/promptLoader.ts`** ~L101
+
+现有逻辑：`targetLanguage.split("-")[0]` → `zh-Hant` 会变成 `zh`，LLM 收到的提示是「翻译成中文」而非「翻译成繁体中文」。
+
+修改方案：在 split 之前增加 `zh-Hant` 的特殊判断：
+
+```typescript
+// 修改前
+const langCode = targetLanguage.split("-")[0];
+
+// 修改后
+const langCode = targetLanguage === "zh-Hant" ? "zh-Hant" : targetLanguage.split("-")[0];
+```
+
+或更通用的方案，维护一个不应被截断的语言标签白名单：
+
+```typescript
+const FULL_TAG_LANGUAGES = new Set(["zh-Hant"]);
+const langCode = FULL_TAG_LANGUAGES.has(targetLanguage) ? targetLanguage : targetLanguage.split("-")[0];
+```
+
+---
+
+## 风险评估
+
+### 🔴 高风险
+
+| 风险 | 影响 | 应对策略 |
+|------|------|----------|
+| **翻译抑制逻辑改动影响所有语言** | `shouldTriggerTranslationAsync` 和 `isPageLanguageSameAsTarget` 是核心路径，改动可能影响现有 8 种语言的抑制判断 | 1. 改动策略：非中文族保持 `getMainSubtag` 比较（等效于原 `split("-")[0]`），仅对 `zh-*` 语言族启用简繁区分逻辑；2. 编写单元测试覆盖全部 8 种现有语言的抑制场景；3. 新增 zh-Hant 专项测试用例 |
+| **split("-")[0] 是全局性模式** | 代码中有 5 处类似归一化，改动时可能遗漏边界条件或漏改某处 | 1. 本方案明确列出所有需改动的文件和行号；2. 全局搜索 `split("-")` 确认无遗漏；3. 对 5 处归一化逐一分析，仅修改必要的 4 处（第 5 处 `languageDetector.ts` 经分析无需修改） |
+
+### 🟡 中风险
+
+| 风险 | 影响 | 应对策略 |
+|------|------|----------|
+| **Official Cloud API 不支持 zh-Hant** | 后端翻译服务可能不支持繁体中文，用户选择后翻译请求会报错 | 1. 前端不做拦截（因为不确定后端能力），先上线让用户可用；2. 后续与后端确认是否支持；3. 如确认不支持，再考虑前端引擎层增加 fallback 或灰显处理 |
+| **detectBrowserLanguage 改动** | 影响 zh-TW/zh-HK 浏览器新用户的默认语言选择 | 1. 仅在 `split` 回退之前增加精确匹配判断，不改变原有回退逻辑；2. 测试 zh-CN、zh-TW、zh-HK、en-US 等常见浏览器语言的匹配结果 |
+
+### 🟢 低风险
+
+| 风险 | 影响 | 应对策略 |
+|------|------|----------|
+| **UI option 添加** | 纯 HTML 添加，不影响逻辑 | 无需特殊应对 |
+| **LANGUAGE_NAME_MAP 添加** | 纯数据映射新增 | 无需特殊应对 |
+
+---
+
+## 验证计划
+
+### 单元测试
+
+1. **`isSameLanguage` 函数测试**（新增）：
+   - `zh-CN` vs `zh-Hant` → `false`（简体页面不应抑制繁体翻译）
+   - `zh-TW` vs `zh-Hant` → `true`（繁体页面应抑制繁体翻译）
+   - `zh-Hans` vs `zh-Hant` → `false`
+   - `zh` vs `zh-Hant` → `false`（无 region 的 zh 视为简体）
+   - `en` vs `zh-Hant` → `false`
+   - `en` vs `en` → `true`（回归验证）
+   - `ja` vs `en` → `false`（回归验证）
+   - `ko` vs `ja` → `false`（回归验证）
+
+2. **`normalizeLanguageTag` / `normalizeLangTag` 测试**（调整）：
+   - 输入 `zh-Hant` 输出 `zh-Hant`（不再截断）
+   - 输入 `ZH-hant` 输出 `zh-Hant`（大小写归一化）
+   - 输入 `en` 输出 `en`（回归验证）
+
+3. **`detectBrowserLanguage` 测试**（新增）：
+   - `navigator.language = "zh-TW"` → 返回 `"zh-Hant"`
+   - `navigator.language = "zh-HK"` → 返回 `"zh-Hant"`
+   - `navigator.language = "zh-CN"` → 返回 `"zh"`（回归验证）
+   - `navigator.language = "en-US"` → 返回 `"en"`（回归验证）
+
+### E2E / 手动验证
+
+1. **简体页面 → 繁体目标**：打开知乎（zh-CN 页面），划词翻译，确认翻译功能正常触发（不被抑制），翻译结果为繁体中文。
+2. **繁体页面 → 繁体目标**：打开苹果台湾官网（zh-TW 页面），划词翻译，确认翻译功能被正确抑制。
+3. **英文页面 → 繁体目标**：打开 BBC 英文站，划词翻译，确认翻译功能正常触发，翻译结果为繁体中文。
+4. **繁体页面 → 简体目标**：打开繁体页面，目标设为简体中文，确认翻译功能正常触发（不被抑制）。
+5. **现有语言回归**：目标设为英文/日文/韩文等，在中文页面上划词翻译，确认行为与改动前一致。
+6. **UI 验证**：popup 和 options 页面的语言下拉列表中可见「繁體中文」选项，选中后正确保存。
+7. **各引擎验证**：分别使用 Microsoft Free、Google Free、Bing Translate、MTranServer 引擎，目标设为繁体中文，确认翻译正常。
+
+---
+
+## 关联信息
+
+- **Issue**: https://github.com/hongyuan007/tapword-translator/issues/23
+- **需求文档**: `docs/plan/y2026/month06/m06-traditional-chinese-support/requirement.md`
+- **分支**: `feat/260613/traditional-chinese-support`
+- **BCP 47 参考**: https://www.rfc-editor.org/rfc/rfc5646.txt（语言标签规范）

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/requirement.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/requirement.md
@@ -1,0 +1,107 @@
+# 翻译目标语言支持繁体中文
+
+## 背景
+
+Issue #23 提出需求：当前 tapword-translator 支持的 8 种翻译目标语言（en, zh, es, ja, fr, de, ko, ru）中，中文仅有简体中文（`zh`），缺少繁体中文选项。对于习惯阅读繁体中文的用户（如台湾、香港、澳门及部分海外华人社群），无法将翻译结果输出为繁体中文是明显的体验缺失。
+
+本需求旨在在翻译目标语言列表中新增繁体中文（`zh-Hant`），使用户可以选择将任意源语言文本翻译为繁体中文输出。
+
+## 目标
+
+用户可在 popup 和 options 页面的翻译目标语言下拉框中选择「繁體中文」，选择后翻译引擎正确输出繁体中文结果。
+
+## 范围
+
+### 包含
+
+- **UI 层**：在 `src/3_popup/index.html` 和 `src/4_options/index.html` 的语言 `<option>` 列表中新增繁体中文选项
+- **存储层**：在 `storageManager.ts` 的 `SUPPORTED_LANGUAGES` 数组中新增 `zh-Hant`
+- **显示层**：在 `languageDisplay.ts` 的 `LANGUAGE_NAME_MAP` 中新增 `zh-Hant` → "繁體中文" 映射
+- **引擎层**：确认各免费引擎 `LANGUAGE_CODE_MAP` 中 `zh-Hant` 映射正确可用（调研显示已预留）
+- **翻译抑制**：确保 `suppressNativeLanguage` 逻辑能正确识别繁体中文页面，避免对已是繁体中文的页面执行翻译
+- **i18n 层**：8 个 locale 文件中补充与繁体中文选项相关的 i18n key（如有需要）
+
+### 不包含
+
+- 不做源语言检测的繁简区分（源语言检测仍将 `zh-*` 统一归为 `zh`）
+- 不新增繁体中文 locale 文件（`src/0_common/locales/` 不新增 `zh-Hant.json`）
+- 不修改 Custom LLM 引擎的繁简区分逻辑（本次仅确保免费引擎链路通畅）
+- 不改变现有简体中文（`zh`）的任何行为
+
+## 用户场景
+
+### 场景1：翻译为繁体中文
+
+1. 用户在浏览器中选中一段英文文本
+2. popup 弹出，用户在「翻译为」下拉框中选择「繁體中文」
+3. 翻译引擎接收 `zh-Hant` 作为目标语言代码
+4. 翻译结果以繁体中文显示在 popup 中
+5. 设置自动保存，后续翻译默认输出繁体中文
+
+### 场景2：繁体中文页面的翻译抑制
+
+1. 用户浏览一个繁体中文网页（`<html lang="zh-TW">` 或 `zh-Hant`）
+2. 用户已将翻译目标语言设为繁体中文（`zh-Hant`）
+3. `suppressNativeLanguage` 逻辑检测到页面语言与目标语言一致，抑制翻译行为
+4. 不对已是目标语言的页面执行冗余翻译
+
+## 技术现状（基于调研）
+
+### 引擎层
+
+所有免费翻译引擎的 `LANGUAGE_CODE_MAP` **已预留 `zh-Hant` 映射**，无需新增代码：
+
+| 引擎 | zh-Hant 映射目标 | 状态 |
+|------|------------------|------|
+| Microsoft Free | `zh-Hant`（直传） | ✅ 已就绪 |
+| Google Free | `zh-TW` | ✅ 已就绪 |
+| Bing Translate | `zh-Hant`（直传） | ✅ 已就绪 |
+| MTranServer | `zh-Hant`（直传） | ✅ 已就绪 |
+| Official Cloud API | 直接传 `targetLanguage` 字段 | ⚠️ 需确认后端是否支持 `zh-Hant` |
+| Custom LLM | `zh-TW` 映射为 "Chinese" | ⚠️ 未区分繁简，本次不改动 |
+
+### UI 层
+
+语言列表硬编码在两处 HTML 文件的 `<option>` 标签中：
+
+- `src/3_popup/index.html` — popup 语言选择下拉框
+- `src/4_options/index.html` — options 页面语言设置
+
+需在简体中文（`zh`）选项后追加繁体中文（`zh-Hant`）选项。
+
+### 存储与显示层
+
+- `storageManager.ts`：`SUPPORTED_LANGUAGES` 数组定义所有支持的语言代码，需新增 `zh-Hant`
+- `languageDisplay.ts`：`LANGUAGE_NAME_MAP` 提供语言显示名，需新增 `zh-Hant` → `"繁體中文"`
+
+### i18n 层
+
+`src/0_common/locales/` 下有 8 个语言包文件（en, zh, es, ja, fr, de, ko, ru）。需检查是否有与目标语言名称相关的 i18n key，如有则补充繁体中文对应翻译。
+
+### 浏览器语言检测
+
+当前逻辑通过 `navigator.language` 获取浏览器语言，所有 `zh-*` 变体被 `split("-")[0]` 统一归为 `zh`。翻译抑制逻辑（`suppressNativeLanguage`）需确认是否能正确处理用户选择 `zh-Hant` 后对繁体中文页面的抑制。
+
+## 验收标准
+
+- [ ] 用户可在 popup 的翻译目标语言下拉框中选择「繁體中文」
+- [ ] 用户可在 options 页面的翻译目标语言下拉框中选择「繁體中文」
+- [ ] 选择繁体中文后，翻译结果输出为繁体中文文本
+- [ ] Microsoft Free 引擎正确传递 `zh-Hant` 语言代码
+- [ ] Google Free 引擎正确将 `zh-Hant` 映射为 `zh-TW`
+- [ ] Bing Translate 引擎正确传递 `zh-Hant` 语言代码
+- [ ] Official Cloud API 正确传递 `zh-Hant`（需后端确认支持，若不支持则在文档中标注风险）
+- [ ] 简体中文（`zh`）及其他 7 种现有目标语言功能不受影响
+- [ ] 繁体中文网页（`zh-TW`/`zh-Hant`）在目标语言为 `zh-Hant` 时翻译抑制逻辑正常工作
+- [ ] `SUPPORTED_LANGUAGES` 数组包含 `zh-Hant`
+- [ ] `LANGUAGE_NAME_MAP` 包含 `zh-Hant` → `"繁體中文"` 映射
+- [ ] i18n locale 文件已检查并更新（8 个语言包补充相关 key）
+- [ ] 所有现有测试通过
+- [ ] Chrome 构建成功
+- [ ] Firefox 构建成功
+
+## 关联信息
+
+- Issue: https://github.com/hongyuan007/tapword-translator/issues/23
+- 分支: `feat/260613/traditional-chinese-support`
+- 任务目录: `docs/plan/y2026/month06/m06-traditional-chinese-support/`

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/latest.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/latest.md
@@ -1,0 +1,6 @@
+# Latest Review
+
+**Round**: 01
+**Date**: 2026-06-13
+**Status**: APPROVED WITH CONDITIONS
+**Path**: `round-01/`

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-01/final-review.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-01/final-review.md
@@ -1,0 +1,22 @@
+# Final Review — Round 01
+
+> **日期**: 2026-06-13
+> **结论**: ⚠️ APPROVED WITH CONDITIONS
+
+## 汇总
+
+| 指标 | 值 |
+|------|-----|
+| P0 | 0 |
+| P1 | 0（translationWalker.ts 降级为 follow-up） |
+| P2 | 5 |
+| P3 | 6 |
+| 安全性 | ✅ 无问题 |
+
+## 合并条件
+1. 修复拼写错误 "coalescling" → "coalescing"
+2. 创建 follow-up issue 跟踪 translationWalker.ts
+
+## 子审查报告
+- `subreviews/reviewer-a-deepseek.md` — DeepSeek V4 Pro（thinking=max）
+- `subreviews/reviewer-b-glm.md` — GLM-5.1

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-01/pr-diff.patch
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-01/pr-diff.patch
@@ -1,0 +1,418 @@
+diff --git a/src/0_common/utils/languageDisplay.ts b/src/0_common/utils/languageDisplay.ts
+index 60eed90..baf902c 100644
+--- a/src/0_common/utils/languageDisplay.ts
++++ b/src/0_common/utils/languageDisplay.ts
+@@ -9,6 +9,7 @@ const DEFAULT_FALLBACK_LOCALE = "en"
+ const LANGUAGE_NAME_MAP: Record<string, string> = {
+     en: "English",
+     zh: "中文",
++    "zh-hant": "繁體中文",
+     es: "Español",
+     ja: "日本語",
+     fr: "Français",
+diff --git a/src/0_common/utils/storageManager.ts b/src/0_common/utils/storageManager.ts
+index 6cdd250..d36fd1d 100644
+--- a/src/0_common/utils/storageManager.ts
++++ b/src/0_common/utils/storageManager.ts
+@@ -241,12 +241,19 @@ export async function getUserSettings(): Promise<types.UserSettings> {
+  * @returns Language code for target language
+  */
+ function detectBrowserLanguage(): string {
+-    const SUPPORTED_LANGUAGES = ["en", "zh", "es", "ja", "fr", "de", "ko", "ru"]
++    const SUPPORTED_LANGUAGES = ["en", "zh", "zh-Hant", "es", "ja", "fr", "de", "ko", "ru"]
+ 
+     // Get browser language (e.g., "zh-CN", "en-US", "ja")
+-    // Use optional chaining and nullish coalescing for safe access
++    // Use optional chaining and nullish coalescling for safe access
+     const browserLang = navigator.language || navigator.languages?.[0] || "en"
+ 
++    // Precise match for Traditional Chinese browser languages before split fallback
++    const lowerBrowserLang = browserLang.toLowerCase()
++    if (lowerBrowserLang === "zh-tw" || lowerBrowserLang === "zh-hk" || lowerBrowserLang === "zh-hant") {
++        logger.info("Browser language matched Traditional Chinese:", browserLang)
++        return "zh-Hant"
++    }
++
+     // Extract primary language code (before hyphen)
+     const parts = browserLang.split("-")
+     const primaryLang = parts[0]?.toLowerCase() || "en"
+diff --git a/src/1_content/utils/languageValidator.ts b/src/1_content/utils/languageValidator.ts
+index e2817e6..68ad6c3 100644
+--- a/src/1_content/utils/languageValidator.ts
++++ b/src/1_content/utils/languageValidator.ts
+@@ -15,12 +15,12 @@ const CONTEXT_CHINESE_RATIO_THRESHOLD = 0.10
+ function getPageDeclaredLanguage(): string {
+     if (typeof document === "undefined") return ""
+ 
+-    const htmlLang = normalizeLanguageTag(document.documentElement.lang)
++    const htmlLang = normalizeLanguageTagFull(document.documentElement.lang)
+     if (htmlLang) {
+         return htmlLang
+     }
+ 
+-    const xmlLang = normalizeLanguageTag(document.documentElement.getAttribute("xml:lang"))
++    const xmlLang = normalizeLanguageTagFull(document.documentElement.getAttribute("xml:lang"))
+     if (xmlLang) {
+         return xmlLang
+     }
+@@ -49,6 +49,7 @@ const REGEX_LATIN = /\p{Script=Latin}/gu
+  * - If text matches the target language's native script, we assume the user is a native speaker reading their own language
+  *   and does not need translation.
+  * - For Chinese ('zh'), we use a ratio check because Han characters are shared with Japanese.
++ *   For zh-Hant (Traditional Chinese), we differentiate between Simplified and Traditional script.
+  * - For Japanese ('ja'), we check for Kana (Hiragana/Katakana) which are unique to Japanese.
+  * - For Korean ('ko') and Russian ('ru'), we check for their specific scripts.
+  * - For all languages, we also check the page's `<html lang="...">` metadata as a fast, reliable signal.
+@@ -61,10 +62,13 @@ const REGEX_LATIN = /\p{Script=Latin}/gu
+  * @returns true if translation should be triggered, false if it should be suppressed
+  */
+ export async function shouldTriggerTranslationAsync(text: string, targetLanguage: string, contextText?: string): Promise<boolean> {
+-    const tgtLang = (targetLanguage || "").toLowerCase().split("-")[0] // Normalize 'zh-CN' -> 'zh'
++    const tgtLang = (targetLanguage || "").toLowerCase() // Only lowercase, do NOT split
+     const pageDeclaredLanguage = getPageDeclaredLanguage()
+ 
+-    switch (tgtLang) {
++    // Determine the primary language subtag for switch dispatch
++    const tgtMain = getMainSubtag(tgtLang)
++
++    switch (tgtMain) {
+         case "zh": {
+             // 1. Check if the selection ITSELF is Chinese
+             // Check for Han characters ratio, but allow if Japanese Kana is present
+@@ -84,18 +88,33 @@ export async function shouldTriggerTranslationAsync(text: string, targetLanguage
+                     logger.debug("Allowing translation: Han ratio high but context has Kana → Japanese page")
+                     return true
+                 }
+-                logger.debug("Suppressing translation: Target is Chinese and text is identified as Chinese", {
++                // Detect the script variant of the selected text to differentiate Simplified vs Traditional
++                const textScript = detectChineseScript(text)
++                const textLang = textScript === "traditional" ? "zh-Hant" : "zh"
++                if (isSameLanguage(textLang, tgtLang)) {
++                    logger.debug("Suppressing translation: Target matches text language (same Chinese variant)", {
++                        text: text.substring(0, 20) + "...",
++                        ratio: chineseCount / totalLength,
++                        textScript,
++                        tgtLang,
++                    })
++                    return false
++                }
++                // Text is Chinese but different script variant from target
++                logger.debug("Allowing translation: Chinese text but different script variant", {
+                     text: text.substring(0, 20) + "...",
+-                    ratio: chineseCount / totalLength,
++                    textScript,
++                    tgtLang,
+                 })
+-                return false
++                return true
+             }
+ 
+             // 2. Check page's declared language (fast, synchronous, reliable when set)
+             // Covers cases where the selected text is pure Latin but the page is Chinese.
+-            if (pageDeclaredLanguage === "zh") {
+-                logger.debug("Suppressing translation: Target is Chinese and page metadata declares Chinese", {
++            if (pageDeclaredLanguage && isSameLanguage(pageDeclaredLanguage, tgtLang)) {
++                logger.debug("Suppressing translation: Target is Chinese and page metadata declares same Chinese variant", {
+                     pageDeclaredLanguage,
++                    tgtLang,
+                 })
+                 return false
+             }
+@@ -114,11 +133,17 @@ export async function shouldTriggerTranslationAsync(text: string, targetLanguage
+                     threshold: CONTEXT_CHINESE_RATIO_THRESHOLD,
+                 })
+                 if (contextChineseRatio >= CONTEXT_CHINESE_RATIO_THRESHOLD) {
+-                    logger.debug("Suppressing translation: Target is Chinese and context is Chinese-dominant", {
+-                        contextSnippet: contextText.substring(0, 20) + "...",
+-                        ratio: contextChineseRatio,
+-                    })
+-                    return false
++                    // Detect script of context text to differentiate Simplified vs Traditional
++                    const contextScript = detectChineseScript(contextText)
++                    const contextLang = contextScript === "traditional" ? "zh-Hant" : "zh"
++                    if (isSameLanguage(contextLang, tgtLang)) {
++                        logger.debug("Suppressing translation: Target is Chinese and context is Chinese-dominant (same variant)", {
++                            contextSnippet: contextText.substring(0, 20) + "...",
++                            ratio: contextChineseRatio,
++                            contextScript,
++                        })
++                        return false
++                    }
+                 }
+             }
+ 
+@@ -159,15 +184,15 @@ export async function shouldTriggerTranslationAsync(text: string, targetLanguage
+         default: {
+             // Other languages (es, fr, de, etc.)
+             // Fast-path: check page's declared language before async detection
+-            if (getPageDeclaredLanguage() === tgtLang) {
+-                logger.debug(`Suppressing translation: Target is ${tgtLang} and page declares it via lang attribute`)
++            if (pageDeclaredLanguage && isSameLanguage(pageDeclaredLanguage, tgtLang)) {
++                logger.debug(`Suppressing translation: Target is ${tgtMain} and page declares it via lang attribute`)
+                 return false
+             }
+             // Fallback: rely on async language detection if context is provided
+             if (contextText && contextText.length > 0) {
+                 const { lang: detectedLang } = await detectSourceLanguageAsync(contextText)
+-                if (detectedLang === tgtLang) {
+-                    logger.debug(`Suppressing translation: Target is ${tgtLang} and context detected as ${detectedLang}`)
++                if (detectedLang === tgtMain) {
++                    logger.debug(`Suppressing translation: Target is ${tgtMain} and context detected as ${detectedLang}`)
+                     return false
+                 }
+             }
+@@ -187,9 +212,13 @@ function calculateHanRatioAgainstHanAndLatin(text: string): number {
+     return hanCount / comparableCount
+ }
+ 
+-function normalizeLanguageTag(tag: string | null | undefined): string {
++/**
++ * Full normalization preserving subtags (for Chinese variant comparison).
++ * Returns lowercase with hyphens (e.g., "zh-hant", "zh-tw", "en-us").
++ */
++function normalizeLanguageTagFull(tag: string | null | undefined): string {
+     if (!tag) return ""
+-    return tag.toLowerCase().split("-")[0]?.trim() ?? ""
++    return tag.trim().toLowerCase().replace(/_/g, "-")
+ }
+ 
+ function normalizeLocaleMeta(content: string | null | undefined): string {
+@@ -198,5 +227,74 @@ function normalizeLocaleMeta(content: string | null | undefined): string {
+     const firstToken = content.split(",")[0]?.trim().toLowerCase() ?? ""
+     if (!firstToken) return ""
+ 
+-    return firstToken.split(/[-_]/)[0]?.trim() ?? ""
++    // Replace underscores with hyphens, preserve full tag
++    return firstToken.replace(/_/g, "-")
++}
++
++/**
++ * Check if a language tag represents Traditional Chinese.
++ */
++function isTraditionalChinese(lang: string): boolean {
++    const lower = lang.toLowerCase()
++    return lower.includes("hant") || lower.includes("tw") || lower.includes("hk") || lower.includes("mo")
++}
++
++/**
++ * Extract the primary language subtag (before the first hyphen).
++ */
++function getMainSubtag(lang: string): string {
++    return lang.split("-")[0]?.trim().toLowerCase() ?? ""
++}
++
++/**
++ * Compare page language and target language to decide if translation should be suppressed.
++ * For zh-* languages, differentiate between Simplified and Traditional.
++ * For other languages, only compare the primary subtag (original behavior).
++ */
++function isSameLanguage(pageLang: string, targetLang: string): boolean {
++    const normalizedPage = normalizeLanguageTagFull(pageLang)
++    const normalizedTarget = normalizeLanguageTagFull(targetLang)
++
++    // Exact match
++    if (normalizedPage === normalizedTarget) return true
++
++    const pageMain = getMainSubtag(normalizedPage)
++    const targetMain = getMainSubtag(normalizedTarget)
++
++    // Chinese language family: must differentiate Simplified vs Traditional
++    if (pageMain === "zh" && targetMain === "zh") {
++        const pageIsTraditional = isTraditionalChinese(normalizedPage)
++        const targetIsTraditional = isTraditionalChinese(normalizedTarget)
++        return pageIsTraditional === targetIsTraditional
++    }
++
++    // Non-Chinese: compare primary subtag only (preserves original behavior)
++    return pageMain === targetMain
++}
++
++/**
++ * A set of characters that only appear in Traditional Chinese (not in Simplified).
++ * Used as a heuristic to detect if Chinese text is traditional or simplified.
++ * Not exhaustive but covers the most common discriminating characters.
++ */
++const TRADITIONAL_ONLY_CHARS = new Set(
++    ("愛礙罷備筆畢邊變標佈測廠場暢車陳塵遲醜從達帶單當黨導敵電釣東動獨頓發罰煩訪費廢奮複負蓋幹剛綱個給宮貢構購穀顧僱掛廣歸龜貴國號轟鴻後護劃懷壞歡還匯會渾獲貨禍擊機積飢膚雞級幾計記際劑濟夾鉀價駕堅鉛儉劍漸礁膠腳較節莖驚經頸競舊劇據鋸覺決殼塊寬礦曠況虧來賴藍攔欄覽勞澇樂離禮歷勵隸連憐蓮聯鐮倆糧兩遼裂獵臨鄰靈領嶺劉陸錄慮論腦鬧釀鳥農盤龐賠噴騙貧評撲鋪樸氣遷僑橋竊欽親輕慶區權勸熱認灑傘喪掃澀殺曬閃陝賞燒設審聲勝聖詩時識實適釋壽書術樹雙誰絲鬆蘇雖隨歲損鎖態嘆討騰體塗團脫馱彎萬網衛穩務烏無膽鐘轉壯狀齊維穢濁興譽軒選學醫郵魚圓緣遠雲雜災髒戰張趙鎮爭鄭證織職執質滯種眾軸駐專莊裝髮準濟").split("")
++)
++
++/**
++ * Detect whether Chinese text uses Traditional or Simplified characters.
++ * Uses a heuristic: if any character in the text is a known Traditional-only character,
++ * the text is classified as Traditional.
++ *
++ * @param text - Chinese text to analyze
++ * @returns "traditional", "simplified", or "unknown" (empty/no Han chars)
++ */
++function detectChineseScript(text: string): "traditional" | "simplified" | "unknown" {
++    if (!text) return "unknown"
++    for (const char of text) {
++        if (TRADITIONAL_ONLY_CHARS.has(char)) {
++            return "traditional"
++        }
++    }
++    return "simplified"
+ }
+diff --git a/src/1_content/utils/pageLanguageChecker.ts b/src/1_content/utils/pageLanguageChecker.ts
+index 9dfa663..85fec46 100644
+--- a/src/1_content/utils/pageLanguageChecker.ts
++++ b/src/1_content/utils/pageLanguageChecker.ts
+@@ -20,7 +20,7 @@ const REGEX_CYRILLIC = /\p{Script=Cyrillic}/u;
+ 
+ /**
+  * Detect the page's declared language from HTML metadata.
+- * Returns a normalized base language code (e.g., "zh", "en", "ja").
++ * Returns a normalized full language code preserving subtags (e.g., "zh-cn", "zh-tw", "en", "ja").
+  */
+ function getPageDeclaredLanguage(): string {
+     if (typeof document === 'undefined') return '';
+@@ -31,10 +31,10 @@ function getPageDeclaredLanguage(): string {
+     const xmlLang = normalizeLangTag(document.documentElement.getAttribute('xml:lang'));
+     if (xmlLang) return xmlLang;
+ 
+-    const ogLocale = normalizeLangTag(
++    const ogLocale = normalizeLocaleMeta(
+         document.querySelector('meta[property="og:locale"]')?.getAttribute('content')
+     );
+-    const contentLanguage = normalizeLangTag(
++    const contentLanguage = normalizeLocaleMeta(
+         document.querySelector('meta[http-equiv="content-language"]')?.getAttribute('content')
+     );
+ 
+@@ -71,6 +71,44 @@ function detectLanguageFromContent(): string {
+     return '';
+ }
+ 
++/**
++ * Check if a language tag represents Traditional Chinese.
++ */
++function isTraditionalChinese(lang: string): boolean {
++    const lower = lang.toLowerCase();
++    return lower.includes('hant') || lower.includes('tw') || lower.includes('hk') || lower.includes('mo');
++}
++
++/**
++ * Extract the primary language subtag (before the first hyphen).
++ */
++function getMainSubtag(lang: string): string {
++    return lang.split('-')[0]?.trim().toLowerCase() ?? '';
++}
++
++/**
++ * Compare page language and target language to decide if translation should be suppressed.
++ * For zh-* languages, differentiate between Simplified and Traditional.
++ * For other languages, only compare the primary subtag (original behavior).
++ */
++function isSameLanguage(pageLang: string, targetLang: string): boolean {
++    const normalizedPage = pageLang.trim().toLowerCase().replace(/_/g, '-');
++    const normalizedTarget = targetLang.trim().toLowerCase().replace(/_/g, '-');
++
++    if (normalizedPage === normalizedTarget) return true;
++
++    const pageMain = getMainSubtag(normalizedPage);
++    const targetMain = getMainSubtag(normalizedTarget);
++
++    if (pageMain === 'zh' && targetMain === 'zh') {
++        const pageIsTraditional = isTraditionalChinese(normalizedPage);
++        const targetIsTraditional = isTraditionalChinese(normalizedTarget);
++        return pageIsTraditional === targetIsTraditional;
++    }
++
++    return pageMain === targetMain;
++}
++
+ /**
+  * Determine whether the current page's language matches the given target language.
+  *
+@@ -78,17 +116,17 @@ function detectLanguageFromContent(): string {
+  * 1. HTML metadata (lang attribute, og:locale, content-language meta)
+  * 2. Script-based content sampling (for CJK and Cyrillic scripts)
+  *
+- * @param targetLanguage - User's target translation language (e.g., "zh", "ja", "en")
++ * @param targetLanguage - User's target translation language (e.g., "zh", "zh-Hant", "ja", "en")
+  * @returns true if the page appears to be in the target language
+  */
+ export function isPageLanguageSameAsTarget(targetLanguage: string): boolean {
+-    const tgt = targetLanguage.toLowerCase().split('-')[0] ?? '';
++    const tgt = (targetLanguage || '').toLowerCase();
+     if (!tgt) return false;
+ 
+     // Signal 1: declared language from metadata
+     const declared = getPageDeclaredLanguage();
+     if (declared) {
+-        const match = declared === tgt;
++        const match = isSameLanguage(declared, tgt);
+         logger.debug(`Page declared language: "${declared}", target: "${tgt}", match: ${match}`);
+         return match;
+     }
+@@ -96,7 +134,7 @@ export function isPageLanguageSameAsTarget(targetLanguage: string): boolean {
+     // Signal 2: script-based content sampling
+     const detected = detectLanguageFromContent();
+     if (detected) {
+-        const match = detected === tgt;
++        const match = isSameLanguage(detected, tgt);
+         logger.debug(`Page detected language (content sampling): "${detected}", target: "${tgt}", match: ${match}`);
+         return match;
+     }
+@@ -105,7 +143,21 @@ export function isPageLanguageSameAsTarget(targetLanguage: string): boolean {
+     return false;
+ }
+ 
++/**
++ * Normalize a language tag: lowercase, replace underscores with hyphens, preserve full BCP 47 tag.
++ */
+ function normalizeLangTag(tag: string | null | undefined): string {
+     if (!tag) return '';
+-    return tag.toLowerCase().split(/[-_]/)[0]?.trim() ?? '';
++    return tag.trim().toLowerCase().replace(/_/g, '-');
++}
++
++/**
++ * Normalize locale metadata from og:locale or content-language meta tags.
++ * Takes the first comma-separated token, replaces underscores with hyphens.
++ */
++function normalizeLocaleMeta(content: string | null | undefined): string {
++    if (!content) return '';
++    const firstToken = content.split(',')[0]?.trim().toLowerCase() ?? '';
++    if (!firstToken) return '';
++    return firstToken.replace(/_/g, '-');
+ }
+diff --git a/src/3_popup/index.html b/src/3_popup/index.html
+index 7d6ecb1..01920ad 100644
+--- a/src/3_popup/index.html
++++ b/src/3_popup/index.html
+@@ -113,6 +113,7 @@
+                 <select id="targetLanguage" data-setting="targetLanguage" class="language-select">
+                   <option value="en">English</option>
+                   <option value="zh">中文</option>
++                  <option value="zh-Hant">繁體中文</option>
+                   <option value="es">Español</option>
+                   <option value="ja">日本語</option>
+                   <option value="fr">Français</option>
+diff --git a/src/4_options/index.html b/src/4_options/index.html
+index 3d04ec6..957831f 100644
+--- a/src/4_options/index.html
++++ b/src/4_options/index.html
+@@ -68,6 +68,7 @@
+                 <select id="targetLanguage" data-setting="targetLanguage" class="select-input">
+                   <option value="en">English</option>
+                   <option value="zh">中文</option>
++                  <option value="zh-Hant">繁體中文</option>
+                   <option value="es">Español</option>
+                   <option value="ja">日本語</option>
+                   <option value="fr">Français</option>
+diff --git a/tests/1_content/utils/languageValidator.unit.test.ts b/tests/1_content/utils/languageValidator.unit.test.ts
+index aa1f3fa..007041c 100644
+--- a/tests/1_content/utils/languageValidator.unit.test.ts
++++ b/tests/1_content/utils/languageValidator.unit.test.ts
+@@ -120,7 +120,9 @@ describe("shouldTriggerTranslationAsync", () => {
+         })
+ 
+         it("uses xml:lang when html lang is missing", async () => {
+-            stubDocumentLanguageSignals({ xmlLang: "zh-TW" })
++            // Use zh-CN (simplified) so that isSameLanguage("zh-cn", "zh") → true → suppress.
++            // With zh-TW, the new logic correctly differentiates traditional ≠ simplified → trigger.
++            stubDocumentLanguageSignals({ xmlLang: "zh-CN" })
+ 
+             expect(await shouldTriggerTranslationAsync("Release", "zh")).toBe(false)
+             vi.unstubAllGlobals()

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-01/review-summary.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-01/review-summary.md
@@ -1,0 +1,23 @@
+# Review Summary — Round 01
+
+**状态**: APPROVED WITH CONDITIONS
+**日期**: 2026-06-13
+
+## 双模型 Review 结果
+
+- **Reviewer A (DeepSeek V4 Pro)**: P0×0, P1×2, P2×4, P3×4
+- **Reviewer B (GLM-5.1)**: P0×0, P1×0, P2×5, P3×4
+
+## 关键裁定
+1. translationWalker.ts 截断（A 标 P1）→ 降级为 follow-up issue（不在 proposal 范围内）
+2. 测试覆盖缺失（A 标 P1）→ 降级为 P2（节点3已有独立测试文件 33 tests，A 未看到）
+
+## 合并条件
+1. 修复拼写 "coalescling" → "coalescing"
+2. 创建 follow-up issue: translationWalker.ts zh-Hant 截断
+
+## 产出物
+- `code-review-report.md` — 完整审查报告
+- `review/pr-local/round-01/subreviews/reviewer-a-deepseek.md`
+- `review/pr-local/round-01/subreviews/reviewer-b-glm.md`
+- `review/pr-local/round-01/final-review.md`

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-01/subreviews/reviewer-a-deepseek.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-01/subreviews/reviewer-a-deepseek.md
@@ -1,0 +1,174 @@
+# Reviewer A — Code Review Report（DeepSeek V4 Pro）
+
+> **审查 PR**: feat/260613/traditional-chinese-support
+> **审查范围**: 7 个文件变更
+> **审查日期**: 2026-06-13
+> **审查模型**: deepseek/deepseek-v4-pro（thinking=max）
+
+---
+
+## Findings
+
+### P0
+
+（无 P0 级别问题）
+
+---
+
+### P1
+
+#### P1-1：`translationWalker.ts` 中 `zh-Hant` 截断未修复（全页翻译路径遗漏）
+
+- **文件**: `src/11_full_translate/dom/translationWalker.ts:135`
+- **现状**: `shouldSkipChineseTargetLanguageText()` 中仍使用 `split(/[-_]/)[0]` 归一化 targetLanguage，`zh-Hant` 被截断为 `zh`
+- **影响**: 用户在简体中文页面使用全页翻译（目标 `zh-Hant`）时，`shouldSkipChineseTargetLanguageText` 会将所有中文块视为「已是目标语言」而跳过，导致全页翻译功能对繁体中文目标**完全失效**
+- **证据**: 
+  ```typescript
+  // 当前代码（未修改）
+  const normalizedTarget = (targetLanguage || '').toLowerCase().split(/[-_]/)[0] ?? '';
+  if (normalizedTarget !== CHINESE_TARGET_LANG) return false; // zh-Hant → zh → 等于 CHINESE_TARGET_LANG → 进入跳过逻辑
+  ```
+- **修复建议**: 同步引入 `isTraditionalChinese` / `isSameLanguage` 或至少将 `zh-Hant` 也纳入 `CHINESE_TARGET_LANG` 的比较范围，避免误跳过。简繁页面相互转换时应始终触发翻译
+- **严重性**: P1 — 全页翻译路径功能回归，合并前必须修复
+
+#### P1-2：繁体中文场景缺少单元测试覆盖
+
+- **文件**: `tests/1_content/utils/languageValidator.unit.test.ts`
+- **现状**: 测试文件只有 1 处适配性修改（`xml:lang` 测试从 `zh-TW` 改为 `zh-CN`），零新增测试用例
+- **技术方案中列出的测试场景全部未实现**:
+  - `isSameLanguage("zh-CN", "zh-Hant") → false`（简体页面不应抑制繁体翻译）
+  - `isSameLanguage("zh-TW", "zh-Hant") → true`（繁体页面应抑制繁体翻译）
+  - `isSameLanguage("zh", "zh-Hant") → false`（无 region 的 zh 视为简体）
+  - `detectBrowserLanguage("zh-TW") → "zh-Hant"`
+  - `detectBrowserLanguage("zh-HK") → "zh-Hant"`
+  - `shouldTriggerTranslationAsync("你好世界", "zh-Hant") → true`（简体文本 + 繁体目标 → 触发翻译）
+  - 等
+- **风险**: 
+  - `isTraditionalChinese` 的 `includes("tw")` 在目标语言为 `"zhtw"`（无连字符）时应正确返回 true（当前 `includes` 实现可以匹配）
+  - `getMainSubtag` 在输入为 `""` 时的行为已用 `?.` 和 `??` 保护，但未显式测试
+  - `detectChineseScript` 的字符集准确性无法通过测试验证
+  - 未来重构 `isSameLanguage` 等函数时缺少保障
+- **修复建议**: 按方案中的测试计划新增至少 10 个测试用例，覆盖所有新增函数的边界条件
+- **严重性**: P1 — 核心路径改动缺少测试保障，合并前必须补充
+
+---
+
+### P2
+
+#### P2-1：`isSameLanguage` / `isTraditionalChinese` / `getMainSubtag` 在 `languageValidator.ts` 和 `pageLanguageChecker.ts` 之间重复
+
+- **影响范围**: 
+  - `languageValidator.ts` L230-280：`isSameLanguage`, `isTraditionalChinese`, `getMainSubtag`
+  - `pageLanguageChecker.ts` L74-107：相同的三个函数（实现完全相同，仅引号风格差异）
+- **问题**: 两份逻辑必须同步维护。如果将来需要支持其他带子标签的语言（如 `pt-BR` vs `pt-PT`），两处都需修改
+- **修复建议**: 将 `isSameLanguage`、`isTraditionalChinese`、`getMainSubtag`、`normalizeLanguageTagFull` 提取到 `src/1_content/utils/` 下的共享模块（如 `languageTagUtils.ts`），由两个消费方分别导入。注意：`pageLanguageChecker.ts` 的 `normalizeLocaleMeta` 与 `languageValidator.ts` 的实现有微妙差异（一个用 `replace(/_/g, '-')`，一个也如此——实际上两者已经一致，提取后消除这个隐患）
+- **严重性**: P2 — 中等可维护性风险，建议本 PR 处理
+
+#### P2-2：`detectChineseScript` 字符集覆盖度不足
+
+- **文件**: `languageValidator.ts` L286-291
+- **现状**: `TRADITIONAL_ONLY_CHARS` 包含约 280 个字符，但存在较明显的漏字：
+  - 缺「門」（门）、「開」（开）、「關」（关）、「長」（长）、「馬」（马）、「沒」（没）、「見」（见）、「說」（说）、「語」（语）、「問」（问）、「間」（间）、「聞」（闻）、「閒」（闲）等大量常用繁体字
+  - 实际生产中，简繁转换对照表通常有 **2000-3000+** 个字符对（如 OpenCC 的标准词典）
+- **影响分析**: 
+  - **假阴性（繁体文本被误判为简体）**: 如果用户选中一组只含共享字符的繁体文本，`detectChineseScript` 返回 `"simplified"`。此时 `textLang = "zh"`（视为简体），与 `tgtLang = "zh-Hant"` 比较 → `isSameLanguage` 返回 `false` → **翻译仍然触发**。**行为正确，无功能缺陷**。
+  - **假阳性（简体文本被误判为繁体）**: 如果简体文本中偶然包含某个也在 `TRADITIONAL_ONLY_CHARS` 中的字符（几乎不可能——这些确实都是繁体专属字符），则会导致错误抑制。**风险极低**。
+- **结论**: 当前实现是 **安全但有损的**——不会造成错误的翻译抑制（不会漏掉需要的翻译），但可能对明显是繁体的文本错过抑制机会（无需翻译时仍显示图标）。建议在 PR 描述中标注字符集为启发式实现、非穷举，后续可迭代补充
+- **严重性**: P2 — 有用户可感知的行为（不必要的翻译图标显示），但不影响功能正确性
+
+#### P2-3：`detectLanguageFromContent` 无法区分简繁，导致无 lang 元数据的繁体页面显示不必要的浮动按钮
+
+- **文件**: `pageLanguageChecker.ts` L49-67
+- **现状**: `detectLanguageFromContent` 对所有 Han-dominant 页面统一返回 `"zh"`，不区分简繁
+- **影响**: 
+  - 无 `<html lang>` 属性的繁体中文页面 + 用户目标 `zh-Hant` → `detectLanguageFromContent` 返回 `"zh"` → `isSameLanguage("zh", "zh-Hant")` → main="zh" 同为 true，但传统判定一个 false 一个 true → 不匹配 → **浮动翻译按钮仍会显示**
+  - 虽然不会错误地抑制翻译（安全），但会给用户呈现一个无意义的浮动按钮
+- **修复建议**: 可考虑在 `detectLanguageFromContent` 中也加入简繁检测（对 Han-dominant body text 调用 `detectChineseScript` 或类似逻辑），使返回值为 `"zh"` 或 `"zh-Hant"`
+- **严重性**: P2 — 次要 UX 问题，非阻塞
+
+#### P2-4：`languageValidator.ts` 中 default 分支的 `detectedLang === tgtMain` 比较存在语义不一致
+
+- **文件**: `languageValidator.ts` L190-195
+- **现状**: 
+  ```typescript
+  const { lang: detectedLang } = await detectSourceLanguageAsync(contextText)
+  if (detectedLang === tgtMain) {
+  ```
+  - `detectedLang` 来自 `detectSourceLanguageAsync` → `normalizeLangCode`，始终是主标签（如 `"es"`, `"fr"`）
+  - `tgtMain` = `getMainSubtag(tgtLang)`，对于 `"zh-Hant"` 就是 `"zh"`
+  - **但** default 分支不会命中 `"zh-Hant"`（因为 `getMainSubtag("zh-Hant") === "zh"`，已经被 `case "zh":` 捕获）
+- **结论**: 当前行为对现有语言 **完全兼容**（等于原来的 `split("-")[0]` 比较），无回归；`zh-Hant` 不会走到这个分支。**无实际 bug**
+- **建议**: 可在注释中明确说明此处的语义等价性，避免后续维护时产生歧义
+- **严重性**: P2 — 低风险的语义不一致，建议加注释澄清
+
+---
+
+### P3
+
+#### P3-1：`storageManager.ts` 中的拼写错误（pre-existing）
+
+- **文件**: `storageManager.ts` L247
+- **现状**: 注释 "nullish coalescling" 应为 "nullish coalescing"
+- **严重性**: P3 — 次要拼写，不影响功能
+
+#### P3-2：Custom LLM 路径的 `zh-Hant` 截断（已知局限性）
+
+- **文件**: `src/8_generate/utils/promptLoader.ts` L102
+- **现状**: `language?.split("-")[0]` 会将 `zh-Hant` 截断为 `zh`，LLM 收到的提示是「翻译成中文」而非「翻译成繁体中文」
+- **处理**: 技术方案中明确标注为**本次不改动**（"不修改 Custom LLM 引擎的繁简区分逻辑"），这是已知的局限性
+- **建议**: 创建 follow-up issue 跟踪，或在产品文档中标注 Custom LLM 引擎的繁体支持为「部分就绪」（有后端能力但前端未透传正确的语言代码）
+- **严重性**: P3 — 已知局限性，有文档说明
+
+#### P3-3：`detectChineseScript` 对空文本返回值 `"unknown"` 时的默认处理缺少注释
+
+- **文件**: `languageValidator.ts` L94
+- **现状**: 
+  ```typescript
+  const textScript = detectChineseScript(text)
+  const textLang = textScript === "traditional" ? "zh-Hant" : "zh"
+  ```
+  当 `textScript === "unknown"` 时，走到 `: "zh"` 分支。行为是正确的（空文本不应抑制翻译），但意图不显式
+- **建议**: 添加注释说明当检测结果为 `"unknown"` 时默认视为简体（不应抑制翻译）
+- **严重性**: P3 — 代码可读性改进
+
+#### P3-4：HTML option 标签的 `value="zh-Hant"` 未序列化/反序列化验证
+
+- **文件**: `src/3_popup/index.html:116`、`src/4_options/index.html:71`
+- **现状**: option 值直接写为 `value="zh-Hant"`，未在 JS 层做值有效性校验。若将来从 HTML 渲染方式改为 JS 动态生成，有可能出现值与 storage 不一致的风险
+- **当前评估**: 现有架构中 `targetLanguage` 通过 `data-setting` 属性绑定存储层读取，校验链在 `storageManager.ts` 中。`zh-Hant` 已添加到 `SUPPORTED_LANGUAGES`，校验路径畅通
+- **严重性**: P3 — 低风险，但可作为后续架构改进（统一语言数据源）的提示
+
+---
+
+## Open Questions
+
+1. **`detectChineseScript` 字符集完整度** — 现有 ~280 个字符已覆盖最常见歧义字，但是否有正式来源（如 Unicode Unihan 数据库的 kSimplifiedVariant 字段？）可用来生成更完整的列表？建议在 PR 描述或注释中标注字符集来源与选取标准。
+
+2. **`zh` vs `zh-Hans`** — 当用户目标语言为 `zh` 时，BZP 47 标准中 `zh` 等于 `zh-Hans`（默认为简体中文）。但 `isTraditionalChinese("zh")` 返回 `false`（正确）。如果将来引入 `zh-Hans` 作为显式选项，需要确保 `isTraditionalChinese("zh-Hans")` 也返回 `false`（当前 `includes("hans")` 不匹配，`includes("tw/hk/mo")` 也不匹配 → 返回 `false`，正确 ✅）。
+
+3. **`navigator.languages` 回退逻辑** — `detectBrowserLanguage` 新增了 `navigator.languages?.[0]` 作为 `navigator.language` 的 fallback。繁体匹配逻辑在 `split` 之前执行，但对于 `navigator.languages = ["zh-TW", "en"]`，如果 `navigator.language` 为空，当前的 `navigator.languages[0]` 能正确取到 `"zh-TW"` 并匹配。✅ 但如果没有 `navigator.language` **且** `navigator.languages` 也为空，则回退到 `"en"`——这是否合理？取决于产品预期。
+
+4. **i18n locale 文件** — 技术方案中提到需检查 8 个 locale 文件，确认是否有与目标语言名称相关的 i18n key。本次 diff 中未包含 locale 文件变更。现有 HTML 中的语言选项名称（如 "English", "中文", "繁體中文"）是直接硬编码的——这符合现有模式。**不需要改动**。
+
+---
+
+## Change Summary
+
+本 PR 实现了翻译目标语言支持繁体中文（`zh-Hant`）的核心功能，采用方案 B（完整方案），修改了 UI 层（popup/options HTML）、存储层（`storageManager.ts`）、显示层（`languageDisplay.ts`）和翻译抑制逻辑（`languageValidator.ts`/`pageLanguageChecker.ts`）。核心设计在于将语言标签归一化从「截断至主标签」升级为「保留完整 BCP 47 标签 + 简繁智能比较」。整体架构合理：通过 `isSameLanguage` 将中文族的简繁区分封装为独立逻辑，非中文族保持原有主标签比较行为；`detectChineseScript` 使用启发式字符集检测文本的简繁属性。回归路径对 `ja/ko/ru/en` 及其他拉丁语系语言完全兼容。
+
+**但有 1 个遗漏点**：全页翻译模块（`translationWalker.ts`）的 `shouldSkipChineseTargetLanguageText` 仍使用旧的 `split` 截断逻辑，导致 `zh-Hant` 在全页翻译路径中失效。此外，繁体中文场景的单元测试完全缺失，核心函数变更缺乏自动化验证保障。
+
+---
+
+## Residual Risks
+
+| # | 风险 | 影响范围 | 缓解建议 |
+|---|------|----------|----------|
+| 1 | **全页翻译路径 `zh-Hant` 截断**（P1-1） | `11_full_translate` 用户选繁体目标时全页翻译功能失效 | 本 PR 必须同步修复 `translationWalker.ts:135` |
+| 2 | **测试覆盖缺失**（P1-2） | 新增函数的回归保障为零，未来重构风险高 | 补充 10+ 单元测试（isSameLanguage / detectChineseScript / detectBrowserLanguage / shouldTriggerTranslationAsync zh-Hant 场景） |
+| 3 | **`detectChineseScript` 字符集覆盖** | 繁体文本被误判为简体时不会导致翻译被错误抑制（安全），但可能漏掉抑制机会（不必要的图标显示） | 标注字符集为启发式，后续迭代补充完整映射表 |
+| 4 | **代码重复**（P2-1） | `languageValidator.ts` 和 `pageLanguageChecker.ts` 中 `isSameLanguage` 等函数重复，未来修改需同步两处 | 提取到 `1_content/utils/languageTagUtils.ts` |
+| 5 | **Content sampling 不区分简繁**（P2-3） | 无 lang 属性的繁体页面会显示不必要的浮动按钮 | 在 `detectLanguageFromContent` 中加入简繁检测 |
+| 6 | **Custom LLM 不支持 zh-Hant 透传** | LLM 引擎用户选繁体中文时，后端收到的是 `zh` 而非 `zh-Hant` | 已知局限性，创建 follow-up issue |
+| 7 | **浏览器兼容性** | `Intl.DisplayNames.of()` 在旧版浏览器可能不支持（已有 try-catch 回退到 `LANGUAGE_NAME_MAP`），`zh-Hant` 已添加到 MAP | ✅ 回退链路已覆盖 |
+| 8 | **`resolveTargetLanguage` 中的简繁比较** | 当前使用原始字符串比较（不做 split），`sourceLanguage = "zh"` ≠ `targetLanguage = "zh-Hant"` → 不触发回退 → 行为正确 ✅ | 无需修改 |

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-01/subreviews/reviewer-b-glm.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-01/subreviews/reviewer-b-glm.md
@@ -1,0 +1,179 @@
+# Code Review Report — Reviewer B (GLM-5.1)
+
+> **PR**: 翻译目标语言支持繁体中文
+> **分支**: `feat/260613/traditional-chinese-support`
+> **审查日期**: 2026-06-13
+> **审查模型**: zai/glm-5.1
+> **审查方式**: 逐文件完整读取 + 零信任分析
+
+---
+
+## Findings
+
+### P0
+
+无。
+
+### P1
+
+无。
+
+### P2
+
+#### P2-1：`isTraditionalChinese` / `getMainSubtag` / `isSameLanguage` 在两个文件中完全重复
+
+**文件**: `src/1_content/utils/languageValidator.ts`、`src/1_content/utils/pageLanguageChecker.ts`
+
+`isTraditionalChinese`、`getMainSubtag`、`isSameLanguage` 三个函数在 `languageValidator.ts`（L228-260）和 `pageLanguageChecker.ts`（L74-108）中以几乎完全相同的实现重复存在。此外，两个文件中的归一化函数（`normalizeLanguageTagFull` vs `normalizeLangTag`）逻辑完全相同，仅函数名不同。
+
+这违反了项目规则中明确的编码规范：
+> "Reuse existing shared types/utilities instead of duplicating them."
+
+**风险**: 未来修改 `isSameLanguage` 逻辑时可能遗漏其中一处，导致两个路径的抑制行为不一致。
+
+**建议**: 将这些函数抽取到 `src/0_common/utils/` 下的共享模块（如 `languageCompare.ts`），两个文件统一 import。可在本 PR 修复或作为紧随的技术债 issue。
+
+#### P2-2：`pageLanguageChecker.ts` 的 `detectLanguageFromContent()` 仍返回 `'zh'`，无法区分繁简
+
+**文件**: `src/1_content/utils/pageLanguageChecker.ts` L53-69
+
+`detectLanguageFromContent()` 通过脚本采样检测页面语言，对中文内容统一返回 `'zh'`（不含 region/script 子标签）。当页面没有 `<html lang>` 元数据时，此函数是唯一的回退信号。
+
+**场景**: 繁体中文页面（如 `<html lang="zh-TW">` 缺失），目标语言为 `zh-Hant`：
+- `detectLanguageFromContent()` 返回 `'zh'`
+- `isSameLanguage('zh', 'zh-hant')` → `getMainSubtag` 均为 `'zh'`，但 `isTraditionalChinese('zh')` 为 `false`，`isTraditionalChinese('zh-hant')` 为 `true` → 返回 `false`
+- 结论：不抑制翻译 → 繁体页面上仍会显示翻译图标
+
+这是功能缺陷（非回归）—— 在没有元数据的繁体页面上，翻译抑制不生效。但影响范围有限：现代网站普遍设置 `<html lang>`。
+
+**建议**: 考虑在 `detectLanguageFromContent()` 中对检测到的中文内容进一步做 `detectChineseScript` 判断（但需注意该函数目前是 `pageLanguageChecker.ts` 的内部函数，且 `detectChineseScript` 定义在 `languageValidator.ts` 中——又一个重复/耦合问题）。可作为后续优化项。
+
+#### P2-3：未新增 zh-Hant 相关的单元测试
+
+**文件**: `tests/1_content/utils/languageValidator.unit.test.ts`
+
+本 PR 对核心翻译抑制逻辑做了重大修改（`isSameLanguage`、`detectChineseScript`、`normalizeLanguageTagFull`），但测试文件仅修改了一个既有用例（将 `xmlLang: "zh-TW"` 改为 `xmlLang: "zh-CN"` 以适配新逻辑），**未新增任何 zh-Hant 场景的测试**。
+
+方案文档明确列出了应有的测试用例：
+- `isSameLanguage` 的各种组合（zh-CN vs zh-Hant、zh-TW vs zh-Hant、zh-Hans vs zh-Hant、zh vs zh-Hant、en vs zh-Hant 等）
+- `detectChineseScript` 对繁体/简体文本的判定
+- `detectBrowserLanguage` 对 zh-TW/zh-HK 浏览器语言的匹配
+
+缺少这些测试意味着回归保护不足。虽然现有测试通过（验证了既有行为不被破坏），但新功能的正确性未被自动化测试覆盖。
+
+**建议**: 本 PR 应补充以下测试：
+1. `shouldTriggerTranslationAsync` 传入 `"zh-Hant"` 目标语言的各种场景
+2. 简体文本 + zh-Hant 目标 → 触发翻译（核心修复点）
+3. 繁体文本 + zh-Hant 目标 → 抑制翻译
+4. 繁体文本 + zh 目标 → 触发翻译
+5. 繁体页面元数据（zh-TW）+ zh-Hant 目标 → 抑制翻译
+
+#### P2-4：`detectChineseScript` 的假阴性问题——仅检测特征字符存在性
+
+**文件**: `src/1_content/utils/languageValidator.ts` L268-278
+
+`detectChineseScript` 遍历文本，只要发现一个 `TRADITIONAL_ONLY_CHARS` 中的字符就判定为繁体，否则判定为简体。
+
+**问题**: 许多繁体文本中的部分字符与简体共用（如「你」「好」「世」「界」）。如果选中的短文本恰好不包含任何繁体特征字，就会被误判为简体。
+
+**实际影响场景**: 用户在繁体页面（`zh-TW`）选中「你好世界」，目标语言为 `zh-Hant`：
+- `detectChineseScript("你好世界")` → `"simplified"`（这些字简繁通用）
+- `textLang = "zh"`
+- `isSameLanguage("zh", "zh-hant")` → `false`（简体 ≠ 繁体）
+- 翻译不被抑制 → 用户看到不必要的翻译图标
+
+**影响程度**: 低。仅影响短文本选择的 UX（多展示了一个翻译图标），不影响功能正确性。用户不会对「你好世界」翻译为繁体产生困惑。
+
+**反向误判风险**: 无。`TRADITIONAL_ONLY_CHARS` 中的字符只出现在繁体中，不会将简体误判为繁体。
+
+**建议**: 当前启发式对实用场景可接受。未来可考虑增加简体特征字检测（如「这」「个」「们」「时」等）做双向判断，提高短文本准确率。文档中应标注此局限性。
+
+#### P2-5：引入了拼写错误 "coalescling"
+
+**文件**: `src/0_common/utils/storageManager.ts` L250（diff）
+
+```diff
+-    // Use optional chaining and nullish coalescing for safe access
++    // Use optional chaining and nullish coalescling for safe access
+```
+
+"coalescing" 被错误改为 "coalescling"。
+
+**建议**: 修正拼写。
+
+### P3
+
+#### P3-1：`SUPPORTED_LANGUAGES` 中的 `"zh-Hant"` 是死代码
+
+**文件**: `src/0_common/utils/storageManager.ts` L243
+
+```typescript
+const SUPPORTED_LANGUAGES = ["en", "zh", "zh-Hant", "es", "ja", "fr", "de", "ko", "ru"]
+```
+
+`SUPPORTED_LANGUAGES` 仅在 `primaryLang` 的 `includes()` 检查中使用。`primaryLang` 来自 `browserLang.split("-")[0]?.toLowerCase()`，永远是主语言子标签（如 `"zh"`、`"en"`），不可能是 `"zh-Hant"`。因此 `"zh-Hant"` 在此数组中永远不会被 `includes()` 匹配到——它是一个无效条目。
+
+实际的繁体中文检测由函数中更早的精确匹配分支完成（L255-258）。此数组条目给人「已有支持」的错觉，实际上不起任何作用。
+
+**建议**: 移除 `"zh-Hant"` 或添加注释说明其为文档性质（表明产品支持该语言）。
+
+#### P3-2：`detectBrowserLanguage` JSDoc 注释过时
+
+**文件**: `src/0_common/utils/storageManager.ts` L236-237
+
+```typescript
+/**
+ * Detect browser language and map to supported target language
+ * Supported languages: zh, en, ja, ko, fr, es, ru
+ */
+```
+
+注释中缺少 `zh-Hant` 和 `de`。
+
+**建议**: 更新注释。
+
+#### P3-3：`TRADITIONAL_ONLY_CHARS` 内联大常量
+
+**文件**: `src/1_content/utils/languageValidator.ts` L257-259
+
+约 200 个繁体特征字符以内联字符串形式硬编码在函数定义上方。虽然功能上没有问题，但可读性较差。
+
+**建议**: 可考虑抽取为独立的常量文件或数据文件（如 `traditionalChars.ts`），便于维护和扩展。优先级低。
+
+#### P3-4：归一化函数命名不一致
+
+**文件**: `languageValidator.ts` 使用 `normalizeLanguageTagFull`；`pageLanguageChecker.ts` 使用 `normalizeLangTag`。
+
+两者实现完全相同（lowercase + replace `_` with `-`），但命名风格不一致。如果按 P2-1 的建议抽取到共享模块，此问题自然解决。
+
+---
+
+## Open Questions
+
+1. **Official Cloud API 是否支持 `zh-Hant`？** 方案中标注为「不确定」。如果后端不支持，用户选择繁体中文并使用 Official Cloud API 引擎时会收到错误。前端目前不做拦截。建议与后端确认或在前端引擎层增加 fallback 处理。
+
+2. **Custom LLM 引擎的 `split("-")[0]` 未处理。** 方案中提到 `promptLoader.ts` L101 会将 `zh-Hant` 截断为 `zh`，但本 PR 未修改。需求文档明确说「不修改 Custom LLM」——这意味着 LLM 引擎用户选择繁体中文后，实际收到的是「翻译成中文」提示，可能输出简体。这是已知限制还是遗漏？
+
+3. **`languageDetector.ts` 的 `normalizeLangCode()` 未修改（方案中有意为之）。** 经分析确认安全：该函数的输出会被 `isSameLanguage` 正确处理。但建议在代码注释中标注此依赖关系，避免未来修改 `normalizeLangCode` 时引入回归。
+
+4. **i18n locale 文件是否需要更新？** 需求文档的验收标准提到「8 个语言包补充相关 key」。本次 diff 中未包含 locale 文件改动。需确认是否遗漏或经检查后确认无相关 key。
+
+---
+
+## Change Summary
+
+本 PR 为翻译目标语言新增繁体中文（`zh-Hant`）支持。改动涵盖 7 个文件：(1) UI 层在 popup 和 options 的下拉列表添加 `<option value="zh-Hant">繁體中文</option>`；(2) 显示层和存储层新增对应映射和浏览器语言检测；(3) 核心翻译抑制逻辑（`languageValidator.ts` 和 `pageLanguageChecker.ts`）将原有 `split("-")[0]` 一刀切归一化替换为基于 BCP 47 完整标签的智能比较，对中文族（`zh-*`）区分简繁变体，对其他语言保持主子标签比较（等效原行为）；(4) 新增 `detectChineseScript` 启发式函数通过特征字符集检测繁简；(5) 适配了一个既有测试用例。整体架构合理，对现有语言的回归风险低，但存在代码重复、测试覆盖不足、内容采样无法区分繁简等可维护性/功能覆盖问题。
+
+---
+
+## Residual Risks
+
+1. **`detectChineseScript` 的准确率上限**: 基于特征字符的启发式检测在短文本（<10 字符）场景下有较高的假阴性率（将繁体误判为简体），导致翻译图标在繁体页面上不必要显示。不影响功能正确性，仅影响 UX。
+
+2. **`detectLanguageFromContent()` 无法识别繁体页面**: 当页面缺乏 `<html lang>` 等元数据时，内容采样仅返回 `'zh'`，无法区分繁简。这意味着 `<html lang>` 缺失的繁体页面在目标为 `zh-Hant` 时不会被抑制。
+
+3. **新功能缺乏自动化测试覆盖**: `isSameLanguage`、`detectChineseScript`、`detectBrowserLanguage` 的繁体支持逻辑均无对应的单元测试。手动测试可能覆盖了主要场景，但长期回归保护不足。
+
+4. **Custom LLM 引擎不区分繁简**: 用户选择繁体中文但使用 Custom LLM 引擎时，LLM 收到的提示为「翻译成中文」（非「翻译成繁体中文」），可能输出简体。需确认是否为预期行为。
+
+5. **Official Cloud API 后端支持未确认**: 如果后端不支持 `zh-Hant`，用户使用此引擎时会遇到翻译错误。

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-02/final-review.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-02/final-review.md
@@ -1,0 +1,116 @@
+# Code Review Report — 翻译目标语言支持繁体中文（Round 02）
+
+> **审查日期**: 2026-06-13
+> **审查模式**: 双模型并行 Review
+> - **Reviewer A**: openai/gpt-5.5（thinking=high）
+> - **Reviewer B**: deepseek/deepseek-v4-pro（thinking=max）
+> **审查范围**: 7 个变更文件 + 1 个受影响的关联文件
+
+---
+
+## 最终结论：⚠️ CHANGES_REQUESTED（双模型均未完全 APPROVED）
+
+两位 Reviewer 都认为核心设计方向正确、安全性无问题、非中文族回归风险低，但均发现了需要修复的问题才可合并。
+
+---
+
+## 1. 双模型 Review 结论
+
+| Reviewer | P0 | P1 | P2 | P3 | 结论 |
+|----------|----|----|----|----|------|
+| **A (GPT-5.5)** | 0 | 1 | 2 | 1 | ⚠️ 有条件通过 |
+| **B (DeepSeek V4 Pro)** | 0 | 3 | 3 | 4 | ⚠️ 有条件通过 |
+
+---
+
+## 2. 问题汇总（取并集，按严重性排序）
+
+### P0 — 阻塞合并
+
+无。
+
+### P1 — 合并前必须处理
+
+| # | 问题 | 发现者 | 文件 | 说明 |
+|---|------|--------|------|------|
+| 1 | **translationWalker.ts 截断** | B | `src/11_full_translate/dom/translationWalker.ts:131` | `split(/[-_]/)[0]` 将 zh-Hant 截断为 zh，导致全页翻译路径中简→繁翻译失效。该文件不在 proposal 改动范围内，但属于功能的直接影响对象。**裁定**：创建 follow-up issue，不阻塞本 PR。 |
+| 2 | **代码重复（6+ 函数）** | A + B | languageValidator.ts ↔ pageLanguageChecker.ts | `isSameLanguage`/`isTraditionalChinese`/`getMainSubtag`/`normalizeLanguageTagFull`/`normalizeLocaleMeta`/正则定义在两文件中完全复制，且 `getPageDeclaredLanguage` 两版本已出现逻辑差异（A 版本检查 ogLocale===contentLanguage 一致性，B 版本直接短路）。**裁定**：建议本 PR 提取共享模块，或至少创建技术债 issue。 |
+| 3 | **getPageDeclaredLanguage 逻辑分叉** | B | 同上 | languageValidator 版本验证 ogLocale 与 contentLanguage 一致性后再采纳；pageLanguageChecker 版本直接 `||` 短路。**裁定**：统一逻辑，合并到共享模块时自然解决。 |
+| 4 | **detectChineseScript 对繁简同形文本误判** | A | languageValidator.ts:86-109 | 繁体页面（zh-TW）上选中「你好世界」等繁简同形文本 + 目标 zh-Hant 时，detectChineseScript 返回 "simplified" → 绕过页面语言抑制 → 不必要地触发翻译。**裁定**：GPT-5.5 标为 P1。这是一个真实的抑制逻辑漏洞，但在实际场景中影响有限（翻译引擎会返回相同文本）。建议在 `unknown` 时参考 pageDeclaredLanguage。 |
+
+### P2 — 建议本 PR 或紧随修复
+
+| # | 问题 | 发现者 | 说明 |
+|---|------|--------|------|
+| 5 | detectChineseScript 字符集不完整 | A + B | 约 280 字符，缺少 測、試、練、體、處、變、關、讓 等常见繁体字。假阴性不会导致错误抑制（安全），但会漏掉抑制机会 |
+| 6 | detectLanguageFromContent 不区分简繁 | A + B | 无 html lang 元数据的繁体页面 + 目标 zh-Hant 时浮动按钮仍显示 |
+| 7 | detectBrowserLanguage 漏掉 zh-MO 等 | A | zh-MO、zh-Hant-TW、zh-Hant-HK 等合法标签会 fallback 到 zh |
+| 8 | TRADITIONAL_ONLY_CHARS 数组转 Set 可读性 | B | 建议直接用 Set 定义 |
+
+### P3 — 可选跟进
+
+| # | 问题 | 发现者 |
+|---|------|--------|
+| 9 | LANGUAGE_NAME_MAP 键名大小写不一致 | B |
+| 10 | 归一化函数命名不一致 | A + B |
+| 11 | detectChineseScript 对非中文返回 "simplified" | B |
+| 12 | 正则重复定义（3 个文件） | B |
+
+---
+
+## 3. 共识 vs 独有
+
+### 双模型共识（都发现的问题）
+- ✅ 代码重复（P1/P3 → 取高：P1）
+- ✅ detectChineseScript 字符集不完整（P2）
+- ✅ detectLanguageFromContent 不区分简繁（P2）
+
+### Reviewer A (GPT-5.5) 独有
+- detectChineseScript 繁简同形文本误判（P1）— **关键发现**，B 未注意到
+
+### Reviewer B (DeepSeek V4 Pro) 独有
+- translationWalker.ts 截断（P1）— 范围外但重要
+- getPageDeclaredLanguage 逻辑分叉（P1）— **关键发现**，A 未注意到
+- detectBrowserLanguage 漏掉 zh-MO（P2）
+- TRADITIONAL_ONLY_CHARS 数组转 Set（P2）
+- detectChineseScript 非中文返回 "simplified"（P3）
+- 正则重复定义（P3）
+
+---
+
+## 4. 安全性检查
+
+| 项目 | Reviewer A | Reviewer B | 结论 |
+|------|-----------|-----------|------|
+| XSS | ✅ 无风险 | ✅ 无风险 | 无 DOM 操作、无 innerHTML |
+| 注入 | ✅ 无风险 | ✅ 无风险 | 无 eval、无动态代码 |
+| 数据泄露 | ✅ 无风险 | ✅ 无风险 | 无网络请求新增 |
+| 权限扩展 | ✅ 无风险 | ✅ 无风险 | manifest.json 未修改 |
+| MV3 合规 | ✅ 安全 | ✅ 安全 | service worker 无新持久状态 |
+
+---
+
+## 5. 合并建议
+
+### 必须处理（阻塞合并）
+1. **P1-4 detectChineseScript 繁简同形文本误判**：修改 `detectChineseScript` 返回 `"unknown"` 时不直接判定简体，而是参考 `pageDeclaredLanguage` 做最终决定。或调整 `shouldTriggerTranslationAsync` zh-case 中的判断顺序：先检查 pageDeclaredLanguage 抑制，再检查文本语言。
+
+### 强烈建议（本 PR 处理或创建 issue）
+2. **P1-2 代码重复 + P1-3 逻辑分叉**：提取共享模块 `languageTagUtils.ts`，消除逻辑差异。
+3. **P1-1 translationWalker.ts**：创建 follow-up issue 修复全页翻译路径。
+
+### 可选（P2/P3）
+4. 修复拼写错误 "coalescling" → "coalescing"
+5. 扩充 TRADITIONAL_ONLY_CHARS 字符集
+6. 补充 zh-MO 等浏览器语言标签匹配
+
+---
+
+## 6. 产出物清单
+
+| 文件 | 说明 |
+|------|------|
+| `review/pr-local/round-02/review-manifest.md` | 审查清单 |
+| `review/pr-local/round-02/subreviews/reviewer-a-gpt55.md` | GPT-5.5 完整报告 |
+| `review/pr-local/round-02/subreviews/reviewer-b-deepseek.md` | DeepSeek V4 Pro 完整报告 |
+| `review/pr-local/round-02/final-review.md` | 本文件 |

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-02/review-manifest.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-02/review-manifest.md
@@ -1,0 +1,32 @@
+# Code Change Handoff Manifest — 繁体中文支持
+
+## 1. Change Context
+
+- **Related Documents**:
+  - `docs/plan/y2026/month06/m06-traditional-chinese-support/requirement.md`
+  - `docs/plan/y2026/month06/m06-traditional-chinese-support/proposal.md`
+  - `docs/plan/y2026/month06/m06-traditional-chinese-support/test-report.md`
+- **Task Objectives**:
+  - 在翻译目标语言列表中新增繁体中文（`zh-Hant`），修改 UI/存储/显示/翻译抑制逻辑
+  - 核心修复：将 `zh-*` 语言族的比较从「截断为主标签」升级为「保留完整 BCP 47 标签 + 简繁智能区分」
+- **AI Disclaimer**: 本代码由 AI 助手基于技术方案和本地代码检查生成，**不保证代码逻辑完全正确**，审查者必须独立验证。
+
+## 2. File Change Audit
+
+| File Path | Change Type | Objective Description |
+| :--- | :--- | :--- |
+| `src/3_popup/index.html` | Add | 添加 `<option value="zh-Hant">繁體中文</option>` 选项 |
+| `src/4_options/index.html` | Add | 同上，保持 popup 和 options 一致 |
+| `src/0_common/utils/languageDisplay.ts` | Mod | `LANGUAGE_NAME_MAP` 新增 `"zh-hant": "繁體中文"` 映射 |
+| `src/0_common/utils/storageManager.ts` | Mod | `detectBrowserLanguage()` 在 split 回退前增加 zh-TW/zh-HK/zh-Hant 精确匹配 |
+| `src/1_content/utils/languageValidator.ts` | Mod | 核心：新增 `isSameLanguage`/`isTraditionalChinese`/`detectChineseScript`/`getMainSubtag`/`normalizeLanguageTagFull`；重写 zh-case 简繁区分；`getPageDeclaredLanguage` 保留完整标签 |
+| `src/1_content/utils/pageLanguageChecker.ts` | Mod | 同步：复制相同的语言比较函数；`normalizeLangTag` 保留完整标签 |
+| `tests/1_content/utils/languageValidator.unit.test.ts` | Mod | 1 个回归测试适配：`xmlLang: "zh-TW"` → `"zh-CN"` |
+
+## 3. Reviewer Risk Checklist
+
+- [ ] **Logical Consistency**: `detectChineseScript` 对繁简同形短文本（如「你好世界」）返回 `"simplified"`，可能导致繁体页面上绕过翻译抑制
+- [ ] **Code Duplication**: 6+ 个函数在 `languageValidator.ts` 和 `pageLanguageChecker.ts` 中完全复制，且 `getPageDeclaredLanguage` 两版本已出现逻辑差异
+- [ ] **Scope Completeness**: `translationWalker.ts` 仍使用 `split` 截断 zh-Hant，全页翻译路径可能失效
+- [ ] **Edge Cases**: `detectBrowserLanguage` 漏掉 `zh-MO`、`zh-Hant-TW` 等标签
+- [ ] **Character Set Coverage**: `TRADITIONAL_ONLY_CHARS` 约 280 字符，缺少 測、試、練、體 等常见繁体字

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-02/subreviews/reviewer-a-gpt55.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-02/subreviews/reviewer-a-gpt55.md
@@ -1,0 +1,46 @@
+## Findings
+
+### P0
+无。
+
+### P1
+1. `[src/1_content/utils/languageValidator.ts:86-109,292-299]` 繁体页面上选中“无繁简差异字”的中文文本时，会绕过页面语言抑制
+
+   `shouldTriggerTranslationAsync()` 在中文目标分支里先根据选中文本做 `detectChineseScript()`，且 `detectChineseScript()` 只要没命中 Traditional-only 字符就直接返回 `"simplified"`。因此在 `<html lang="zh-TW">` / `zh-Hant` 页面上，用户选中常见但无繁简差异的文本（例如 `你好世界`、`中文`、`香港` 中部分短词等）且目标语言为 `zh-Hant` 时，流程会得到 `textLang = "zh"`，`isSameLanguage("zh", "zh-hant") === false`，随后在第 109 行直接 `return true`，不会再执行第 112-120 行的页面语言抑制判断。
+
+   这会破坏需求中的核心场景“繁体中文网页 + 目标语言 zh-Hant 时应抑制翻译”。建议不要把“未命中繁体专属字”直接等价为简体：可让 `detectChineseScript()` 返回 `unknown`，在 `unknown` 时继续参考 `pageDeclaredLanguage` / context；或在中文文本分支中，当页面声明语言与目标一致时优先抑制。需要补一个回归用例：`htmlLang: "zh-TW"` + `text: "你好世界"` + `target: "zh-Hant"` 应返回 `false`。
+
+### P2
+1. `[src/1_content/utils/pageLanguageChecker.ts:64-69,134-139]` 无 metadata 的繁体页面无法通过内容采样抑制浮动按钮
+
+   `detectLanguageFromContent()` 对所有“有足够 Han 字符且无 Kana”的页面都返回裸 `"zh"`，没有像 `languageValidator.ts` 一样区分简繁。对没有设置 `<html lang>` / `og:locale` 的繁体页面，目标语言为 `zh-Hant` 时会走到 `isSameLanguage("zh", "zh-hant") === false`，于是 `FloatingButtonIntegration` 会继续显示全页翻译浮动按钮。该路径与本次新增 zh-Hant 的抑制目标不一致。
+
+   建议复用同一套中文脚本判断逻辑：内容采样若能判定为繁体则返回 `zh-Hant`，判定为简体则返回 `zh`；无法判定时再按保守策略处理。最好为 `isPageLanguageSameAsTarget("zh-Hant")` 增加繁体正文、无 metadata 的测试。
+
+2. `[src/0_common/utils/storageManager.ts:250-255]` `detectBrowserLanguage()` 漏掉澳门和带 script+region 的繁体浏览器标签
+
+   需求背景明确覆盖台湾、香港、澳门用户，且 `isTraditionalChinese()` 已把 `mo` 作为繁体地区处理；但新用户默认语言检测只精确匹配 `zh-tw` / `zh-hk` / `zh-hant`。`zh-MO`、`zh-Hant-MO`、`zh-Hant-TW`、`zh-Hant-HK` 等合法/常见 BCP 47 变体都会落回 `split("-")[0]`，最终默认成简体 `zh`。这会让部分繁体用户首次安装体验不符合预期。
+
+   建议改为解析 subtags：只要主语言是 `zh` 且 script 为 `Hant`，或 region 属于 `TW/HK/MO`，就返回 `zh-Hant`；并补充 `zh-MO` / `zh-Hant-TW` 测试。
+
+### P3
+1. `[src/1_content/utils/languageValidator.ts:237-273, src/1_content/utils/pageLanguageChecker.ts:77-110]` 语言标签比较逻辑重复，已出现行为分叉风险
+
+   `isTraditionalChinese` / `getMainSubtag` / `isSameLanguage` 在两个 content util 中重复实现，且 `pageLanguageChecker` 没有同步 `languageValidator` 的文本脚本判断能力。这类逻辑是本功能的核心判定规则，继续复制会让后续新增语言变体或修 bug 时很容易漏改一处。
+
+   建议抽成一个纯工具模块（例如 `src/0_common/utils/languageTagUtils.ts` 或 content 内共享 util），两个调用方统一复用，并围绕该模块写直接单元测试。
+
+## Open Questions
+
+- 本轮按任务指定的 7 个文件审查；工作区中另有未跟踪测试文件（如 traditional-chinese 相关测试）未包含在“7 个文件变更”清单内，最终合并范围需要确认。
+- Official Cloud API / Custom LLM 对 `zh-Hant` 的支持在需求中标为风险/不包含，本轮未审查引擎层实现。
+
+## Change Summary
+
+本次变更在 popup/options 增加 `zh-Hant` 选项，在显示与新用户语言检测中加入繁体中文，并重写 content 侧语言比较逻辑以避免把所有 `zh-*` 都截断成 `zh`；整体方向符合方案 B，但中文脚本启发式与页面语言信号的组合仍有可复现的抑制漏判。
+
+## Residual Risks
+
+- `detectChineseScript()` 的 Traditional-only 字符集启发式不可能覆盖所有短文本，尤其是繁简同形词；如果没有 `unknown` 状态或页面/context 兜底，zh-Hant 抑制会持续存在误判。
+- `pageLanguageChecker` 缺少针对 `zh-Hant` 的直接测试，浮动按钮路径与划词路径可能继续分叉。
+- 未运行构建/测试；本报告基于静态审查。

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-02/subreviews/reviewer-b-deepseek.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-02/subreviews/reviewer-b-deepseek.md
@@ -1,0 +1,251 @@
+# Reviewer B (DeepSeek V4 Pro) — Code Review 报告
+
+> **审查范围**：`feat/260613/traditional-chinese-support` 分支 7 个文件变更
+> **审查日期**：2026-06-13
+> **审查人**：Reviewer B — DeepSeek V4 Pro（深度思考模式）
+
+---
+
+## 审查总览
+
+| 严重性 | 数量 | 说明 |
+|--------|------|------|
+| P0 | 0 | 无安全问题 / 数据丢失 |
+| P1 | 3 | 功能回归风险 + 架构维护风险 |
+| P2 | 3 | 中等正确性 / 可维护性问题 |
+| P3 | 4 | 次要改进建议 |
+
+---
+
+## Findings
+
+### P1 — 高置信度功能回归 / 架构风险
+
+#### P1-1: `translationWalker.ts` 的 `split` 截断导致全页翻译的 Simplified→Traditional 失效
+
+- **文件**：`src/11_full_translate/dom/translationWalker.ts`
+- **位置**：L131，`shouldSkipChineseTargetLanguageText()` 函数
+- **代码**：
+  ```typescript
+  const normalizedTarget = (targetLanguage || '').toLowerCase().split(/[-_]/)[0] ?? '';
+  if (normalizedTarget !== CHINESE_TARGET_LANG) return false; // CHINESE_TARGET_LANG = 'zh'
+  ```
+- **问题**：当 `targetLanguage = "zh-Hant"` 时，`split(/[-_]/)[0]` 结果为 `"zh"`，匹配 `CHINESE_TARGET_LANG`，函数进入跳过逻辑。这导致**在全页翻译（full-page translate）场景下，用户从简体中文页面使用繁体中文为目标时，已经是中文的文本块会被错误跳过，不会执行简体→繁体的翻译**。
+- **影响**：全页翻译功能对 `zh-Hant` 目标语言部分失效。划词翻译不受影响（走的是 `languageValidator.ts` 路径，该文件已正确修复）。
+- **建议**：在 `shouldSkipChineseTargetLanguageText` 中，当 `targetLanguage` 为 `zh-Hant` 且页面文本为简体中文时，不应该跳过。可采用与 `isSameLanguage` 一致的中文变体检测逻辑（即检测原文和目标的简繁属性，异化时不跳过）。
+- **注意**：该文件不在本次 PR 的 7 个变更文件范围内，但确实是本 Feature 的直接影响对象。
+
+#### P1-2: `languageValidator.ts` 与 `pageLanguageChecker.ts` 之间严重代码重复
+
+以下函数在两文件中**完全相同地复制**，没有任何抽象：
+
+| 函数 | languageValidator.ts | pageLanguageChecker.ts |
+|------|---------------------|----------------------|
+| `getPageDeclaredLanguage()` | L16-31 | L61-69（逻辑有细微差异，见下文） |
+| `normalizeLanguageTagFull` / `normalizeLangTag` | L171-174 | L93-96 |
+| `normalizeLocaleMeta()` | L176-183 | L102-107 |
+| `isSameLanguage()` | L198-214 | L61-78 |
+| `isTraditionalChinese()` | L188-191 | L71-75 |
+| `getMainSubtag()` | L194-196 | L78-83 |
+| `REGEX_HAN`/`REGEX_KANA`/`REGEX_HANGUL`/`REGEX_CYRILLIC` | L35-38 | L13-16 |
+
+- **风险**：未来任一处的 `isSameLanguage` 逻辑变更（例如需要支持 `zh-MO` 或 `zh-SG`），必须在两个文件中同步修改。遗忘同步将导致划词翻译和浮动按钮抑制行为不一致，产生难以排查的 Bug。
+- **建议**：将上述共享函数提取到 `src/0_common/utils/languageUtils.ts`或 `src/1_content/utils/languageUtils.ts`，两文件从共享模块导入。
+
+#### P1-3: `getPageDeclaredLanguage()` 两版本存在逻辑差异
+
+- **`languageValidator.ts` 版本**（L16-31）：
+  ```typescript
+  const ogLocale = normalizeLocaleMeta(...)
+  const contentLanguage = normalizeLocaleMeta(...)
+  // 当 ogLocale 和 contentLanguage 都存在且相同时，返回 ogLocale
+  if (ogLocale && contentLanguage && ogLocale === contentLanguage) return ogLocale
+  return ogLocale || contentLanguage || ""
+  ```
+
+- **`pageLanguageChecker.ts` 版本**（L61-69）：
+  ```typescript
+  const ogLocale = normalizeLocaleMeta(...)
+  const contentLanguage = normalizeLocaleMeta(...)
+  // 直接短路返回，不检查一致性
+  return ogLocale || contentLanguage || ''
+  ```
+
+- **差异**：`languageValidator.ts` 版本在 ogLocale 和 contentLanguage 都非空时会验证它们是否一致，不一致时才做 `||` 回退。而 `pageLanguageChecker.ts` 直接使用 `||` 短路，ogLocale 存在时直接返回，**完全忽略 contentLanguage**。这导致相同的 HTML 页面可能在划词翻译抑制和浮动按钮抑制中得出不同结论。
+
+- **建议**：统一逻辑并提取共享。推荐采用 `languageValidator.ts` 的版本（更严谨，两个 meta 标签一致时才采纳）。
+
+---
+
+### P2 — 中等正确性 / 可维护性问题
+
+#### P2-1: `detectChineseScript` 繁体字集不完整
+
+- **文件**：`src/1_content/utils/languageValidator.ts`，L223-226
+- **问题**：`TRADITIONAL_ONLY_CHARS` 包含约 200 个字符，但实际上繁简体不共享的字符数量远超此数。以下常见繁体字不在集合中，导致含有这些字的文本被错误归类为 `"simplified"`：
+
+  | 繁体 | 简体 | 是否在集合中 |
+  |------|------|-------------|
+  | 測 | 测 | ❌ |
+  | 試 | 试 | ❌ |
+  | 練 | 练 | ❌ |
+  | 體 | 体 | ❌ |
+  | 處 | 处 | ❌ |
+  | 變 | 变 | ❌ |
+  | 關 | 关 | ❌ |
+  | 讓 | 让 | ❌ |
+  | 寫 | 写 | ❌ |
+  | 實 | 实 | ❌ |
+  | 際 | 际 | ❌ |
+  | 還 | 还 | ❌ |
+  | 組 | 组 | ❌ |
+
+- **影响**：含上述字符的繁体文本会被判定为简体，从而导致以下错误行为：
+  - **用户场景**：用户浏览繁体页面，目标语言为 `zh-Hant`，划词选中「測試」→ `detectChineseScript` 判定为 `"simplified"` → `isSameLanguage("zh", "zh-Hant")` → `false` → **错误触发翻译**
+  - 这是 **false positive 场景**（不应翻译的繁体文本被翻译），影响相对较小——用户会看到不必要的翻译图标，但不会阻止功能。
+- **严重性降级理由**：即使误判，翻译引擎大概率仍会将繁体原文翻译为繁体结果（零改动翻译），对用户的实际影响有限。且 `getPageDeclaredLanguage()` 信号（如 `<html lang="zh-TW">`）仍可作为补充缓解。
+- **建议**：扩充 `TRADITIONAL_ONLY_CHARS` 集合，可从 Unicode 繁简对照表中批量导入。或改用更稳健的方案，例如基于 Unicode Block 的范围判断（CJK Unified Ideographs 中的 Extended B+ 区域）或引入第三方繁简转换库。
+
+#### P2-2: `TRADITIONAL_ONLY_CHARS` 从数组转 Set 的开销
+
+- **文件**：`src/1_content/utils/languageValidator.ts`，L216-226
+- **问题**：字符集以数组形式定义，在模块加载时通过 `new Set(...)` 转换。数组长度约 200，开销可忽略，但**代码可读性差**——数组格式不利于维护（增删字符时需要手动管理一致性）。
+- **建议**：
+  ```typescript
+  // 直接使用 Set，更干净
+  const TRADITIONAL_ONLY_CHARS: Set<string> = new Set([
+      "愛", "礙", "備", "筆", "畢", /* ... */
+  ])
+  ```
+
+#### P2-3: `normalizeLangCode`（languageDetector.ts）不做区分但被正确调用链处理
+
+- **文件**：`src/1_content/utils/languageDetector.ts`，L129
+- **验证结果**：`normalizeLangCode` 将所有 `zh-*` 变体归一化为 `"zh"`，不修改它。其输出 `"zh"` 随后会被传入 `isSameLanguage`，进而走到 `zh` 族的简繁区分逻辑。两个函数的组合行为是正确的——`normalizeLangCode` 只负责返回主标签，`isSameLanguage` 负责简繁区分。✅
+- **风险等级低**：只要调用链不变，没有问题。但如果未来有人直接使用 `normalizeLangCode` 的输出而不经过 `isSameLanguage`，会丢失简繁信息。
+- **建议**：在 `normalizeLangCode` 的 JSDoc 中添加注释说明它输出主标签，简繁区分由 `isSameLanguage` 处理。
+
+---
+
+### P3 — 次要改进
+
+#### P3-1: `LANGUAGE_NAME_MAP` 键名大小写不一致
+
+- **文件**：`src/0_common/utils/languageDisplay.ts`，L7
+- **代码**：``"zh-hant": "繁體中文"``
+- **问题**：`LANGUAGE_NAME_MAP` 使用全小写键名 `"zh-hant"`，而 HTML option value 使用 `"zh-Hant"`（大写 H）。虽然 `getLanguageDisplayName()` 会先 `toLowerCase()` 再查找，兼容性没问题，但风格不一致。
+- **建议**：统一为 `"zh-Hant"` 键名，或在 HTML 中将 value 统一为全小写。
+
+#### P3-2: 重复的 `normalizeLanguageTagFull` / `normalizeLangTag` 命名不一致
+
+- **文件**：`languageValidator.ts` L171 vs `pageLanguageChecker.ts` L93
+- **问题**：两个函数执行完全相同的逻辑（`trim().toLowerCase().replace(/_/g, '-')`），但命名不同（`normalizeLanguageTagFull` vs `normalizeLangTag`）。如果因 P1-2 将二者提取为共享函数，此问题自然解决。
+
+#### P3-3: `detectChineseScript` 中非中文/非空文本也返回 `"simplified"`
+
+- **文件**：`src/1_content/utils/languageValidator.ts`，L232-238
+- **代码**：
+  ```typescript
+  function detectChineseScript(text: string): "traditional" | "simplified" | "unknown" {
+      if (!text) return "unknown"
+      for (const char of text) {
+          if (TRADITIONAL_ONLY_CHARS.has(char)) return "traditional"
+      }
+      return "simplified"  // ← 对纯英文/纯数字也返回 "simplified"
+  }
+  ```
+- **问题**：函数签名声明可返回 `"unknown"`，但非空文本只返回 `"traditional"` 或 `"simplified"`。调用方 `shouldTriggerTranslationAsync` 在 `case "zh":` 分支中调用此函数，调用前已确认 Han 比例超过 5%，所以当前不存在纯英文文本被传入的风险。但函数本身的设计语义不准确。
+- **建议**：当文本中不包含任何 Han 字符时返回 `"unknown"`，例如：
+  ```typescript
+  let hasHan = false
+  for (const char of text) {
+      if (TRADITIONAL_ONLY_CHARS.has(char)) return "traditional"
+      if (REGEX_HAN.test(char)) hasHan = true
+  }
+  return hasHan ? "simplified" : "unknown"
+  ```
+
+#### P3-4: `REGEX_HAN` 等正则重复定义
+
+- **文件**：`languageValidator.ts` L35-38、`pageLanguageChecker.ts` L13-16、`translationWalker.ts` L18-21
+- **问题**：三个文件各自定义了相同的 Unicode 属性正则（`REGEX_HAN`、`REGEX_KANA`、`REGEX_HANGUL`、`REGEX_CYRILLIC`）。
+  - `REGEX_HAN` 在 `languageValidator.ts` 是 `/\p{Script=Han}/gu`，在 `pageLanguageChecker.ts` 也是 `/\p{Script=Han}/gu`，在 `translationWalker.ts` 也是。
+  - `REGEX_KANA` 和 `REGEX_HANGUL` 表达式完全相同。
+  - `REGEX_CYRILLIC` 定义相同。
+- **建议**：将共享正则提取到 `src/1_content/utils/charsets.ts` 或 `src/0_common/constants/regex.ts`。
+
+---
+
+## Open Questions
+
+1. **Q1：`translationWalker.ts` 是否在本 PR 范围内修复？**
+   - 技术方案中提到了 `promptLoader.ts` 的 split 风险，但未提及 `translationWalker.ts`。该文件的 `shouldSkipChineseTargetLanguageText` 对 `zh-Hant` 的错误截断会直接导致全页翻译功能缺陷。
+   - 如果本 PR 不修复，建议至少在需求文档中标注已知限制，并单独开 Issue 跟进。
+
+2. **Q2：共享工具函数的提取范围？**
+   - `isSameLanguage`、`isTraditionalChinese`、`getMainSubtag` 是本次新增的核心逻辑，目前复制在两文件中。如果未来需要支持更多中文变体（如 `zh-Hans-SG` 新加坡简体、`zh-Hant-MO` 澳门繁体），需要在两处同步修改。
+   - 建议本次 PR 就提取到共享模块（P1-2），避免技术债积累。
+
+3. **Q3：繁体字检测是否需要引入第三方库？**
+   - 当前 200 字符的 `TRADITIONAL_ONLY_CHARS` 是启发式方案。如果想彻底解决 P2-1，可考虑引入 `zhconverter` 或 `opencc-js` 做精确的简繁判别，但这会增加 Bundle 体积。
+   - 权衡：启发式方案足够用（配合 `getPageDeclaredLanguage` 互补），但如果用户期望更高的检测准确率，建议制定中期优化计划。
+
+4. **Q4：`LANGUAGE_NAME_MAP` 是否需要显式的 `"zh"` 显示名？**
+   - 当前 `"zh"` 映射为 `"中文"`，但用户可能期望看到 `"简体中文"` 以示区分。当前 UI 上简体中文和繁体中文相邻排列，足以让用户理解，但也可能造成歧义。建议评估后决定。
+
+---
+
+## Change Summary
+
+| # | 文件 | 变更类型 | 审查结论 |
+|---|------|----------|----------|
+| 1 | `src/3_popup/index.html` | 添加 `<option value="zh-Hant">繁體中文</option>` | ✅ 通过，纯 UI 添加 |
+| 2 | `src/4_options/index.html` | 同上 | ✅ 通过，纯 UI 添加 |
+| 3 | `src/0_common/utils/languageDisplay.ts` | `LANGUAGE_NAME_MAP` 新增 `"zh-hant"` 条目 | ✅ 通过，注意 P3-1 大小写不一致 |
+| 4 | `src/0_common/utils/storageManager.ts` | `SUPPORTED_LANGUAGES` + `detectBrowserLanguage` 修改 | ✅ 通过，边界处理正确 |
+| 5 | `src/1_content/utils/languageValidator.ts` | 核心逻辑重构（`isSameLanguage`/`detectChineseScript`/`isTraditionalChinese`/`getMainSubtag`/`normalizeLanguageTagFull`） | ⚠️ 有条件通过 — P1-2 代码重复 + P2-1 字集不完整 |
+| 6 | `src/1_content/utils/pageLanguageChecker.ts` | 同上逻辑同步 | ⚠️ 有条件通过 — P1-2 代码重复 + P1-3 逻辑差异 |
+| 7 | `tests/1_content/utils/languageValidator.unit.test.ts` | 回归测试适配 | ✅ 通过，测试覆盖充分 |
+| — | `src/11_full_translate/dom/translationWalker.ts` | **未修改**（但受影响） | ❌ **需修复** — P1-1 `split` 截断问题 |
+
+### 兼容性矩阵验证
+
+对现有 8 种目标语言的翻译抑制逻辑进行逻辑推演：
+
+| 目标语言 | 页面语言 | 原行为 | 新行为 | 是否正确 |
+|----------|----------|--------|--------|----------|
+| `zh` | `zh-CN`（简体页面） | 抑制 | 抑制（简体=简体） | ✅ |
+| `zh` | `zh-TW`（繁体页面） | 抑制 | **触发**（繁体≠简体） | ✅ 正确，用户选简体应触发翻译 |
+| `zh-Hant` | `zh-CN`（简体页面） | — | **触发**（简体≠繁体） | ✅ 核心用例 |
+| `zh-Hant` | `zh-TW`（繁体页面） | — | 抑制（繁体=繁体） | ✅ |
+| `en` | `en-US` | 触发 | 触发 | ✅ 保持 |
+| `en` | `en-GB` | 触发 | 触发 | ✅ 保持 |
+| `ja` | `ja` 页面 | 抑制（Kana） | 抑制（Kana） | ✅ 保持 |
+| `ko` | `ko` 页面 | 抑制（Hangul） | 抑制（Hangul） | ✅ 保持 |
+| `ru` | `ru` 页面 | 抑制（Cyrillic） | 抑制（Cyrillic） | ✅ 保持 |
+| `es` | `es` 页面 | 抑制 | 抑制 | ✅ 保持 |
+
+**结论**：中文族的简繁区分逻辑正确，非中文族行为与改动前一致，回归风险低。
+
+---
+
+## Residual Risks
+
+| # | 风险 | 严重性 | 缓解措施 |
+|---|------|--------|----------|
+| R1 | **全页翻译 zh-Hant 失效**（`translationWalker.ts` 未修复） | 🔴 高 | 需在本 PR 或后续 PR 修复 `shouldSkipChineseTargetLanguageText` 中的 split 截断 |
+| R2 | **`detectChineseScript` 启发式误判** | 🟡 中 | 短繁体文本可能被误判为简体，导致不必要的翻译触发（非阻塞性） |
+| R3 | **重复代码导致未来不一致修改** | 🟡 中 | `isSameLanguage` 等在两个文件中的副本，需手动保持同步 |
+| R4 | **用户升级后行为变化** | 🟢 低 | 老用户如果在简体页面上目标为 `zh`（旧行为：抑制→正确），升级后行为不变。老用户默认 targetLanguage 仍为存储的值（`zh`），不会自动切换为 `zh-Hant` |
+| R5 | **Custom LLM / Official Cloud API 对 zh-Hant 的支持** | 🟢 低 | 技术方案已标注为不确定，但不在本 PR 范围内 |
+| R6 | **BCP 47 边界情况**：`zh-Hans-CN`（带 script 和 region 的完整标签） | 🟢 低 | `isTraditionalChinese` 检查 `includes("hant")`，`zh-Hans-CN` 返回 `false`（简体），`zh-Hant-HK` 返回 `true`（繁体）。行为正确。但如果遇到 `zh-cmn-Hant`（Mandarin Chinese with Traditional script），`includes("hant")` 也会正确匹配 |
+
+---
+
+## 总体评估
+
+**建议：有条件通过，修复 P1 项后合并。**
+
+本次 PR 的核心逻辑（`isSameLanguage` 简繁区分）设计合理，错误处理到位，类型安全，对现有语言的回归风险很低。测试覆盖（`languageValidator.unit.test.ts`）已适配。主要阻塞项为 P1 级的 `translationWalker.ts` 截断问题和代码重复问题。
+
+如果是 Reviewer A 和 Reviewer B 双模型并审，**任一发现的问题都需修复**后才算通过。本报告中的 P1 项均建议在合并前解决。

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-03/review-manifest.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-03/review-manifest.md
@@ -1,0 +1,43 @@
+# Code Change Handoff Manifest — 繁体中文支持（Round 03）
+
+## 1. Change Context
+
+- **Related Documents**:
+  - `requirement.md` — 需求文档
+  - `proposal.md` — 技术方案（方案 B）
+  - `test-report.md` — 测试报告
+- **Task Objectives**:
+  - 在翻译目标语言列表中新增繁体中文（zh-Hant）
+  - Round 02 Review 发现 3 个 P1 问题，本轮修复后重新审查
+- **AI Disclaimer**: 本代码由 AI 助手基于技术方案和本地代码检查生成，不保证代码逻辑完全正确，审查者必须独立验证。
+
+## 2. P1 修复说明（Round 02 → Round 03）
+
+| P1 # | 问题 | 修复方式 |
+|-------|------|----------|
+| 1 | detectChineseScript 同形文本误判 | zh-case 中将 pageDeclaredLanguage 检查提到文本分析之前 |
+| 2 | 6+ 函数重复 + getPageDeclaredLanguage 逻辑分叉 | 提取共享模块 `languageTagUtils.ts`，统一两文件 import |
+| 3 | translationWalker.ts split 截断 | 新增 zh-Hant 分支，仅跳过已含繁体字的文本 |
+
+## 3. File Change Audit（Round 03 审查范围）
+
+| File Path | Change Type | Lines Changed | Objective |
+| :--- | :--- | :--- | :--- |
+| `src/3_popup/index.html` | Add | +1 | 添加 zh-Hant option |
+| `src/4_options/index.html` | Add | +1 | 同上 |
+| `src/0_common/utils/languageDisplay.ts` | Mod | +1 | LANGUAGE_NAME_MAP 新增 |
+| `src/0_common/utils/storageManager.ts` | Mod | +11/-4 | detectBrowserLanguage 精确匹配 |
+| `src/0_common/utils/languageTagUtils.ts` | **New** | +58 | 共享语言标签工具模块 |
+| `src/1_content/utils/languageValidator.ts` | Mod | +125/-55 | 核心逻辑 + P1-1 修复 + import 共享模块 |
+| `src/1_content/utils/pageLanguageChecker.ts` | Mod | +29/-7 | import 共享模块 + 统一 getPageDeclaredLanguage |
+| `src/11_full_translate/dom/translationWalker.ts` | Mod | +32 | P1-3: zh-Hant 分支 |
+| `tests/.../languageValidator.unit.test.ts` | Mod | +4/-4 | 回归测试适配 |
+
+## 4. Reviewer Risk Checklist
+
+- [ ] **P1-1 修复有效性**：zh-TW 页面选「你好世界」+ zh-Hant 目标 → 应被 pageDeclaredLanguage 先行抑制
+- [ ] **P1-2 共享模块正确性**：import 后行为是否与原内联定义一致
+- [ ] **P1-3 translationWalker 逻辑**：zh-Hant 分支是否正确——仅跳过含繁体字的文本
+- [ ] **getPageDeclaredLanguage 统一**：两版本现在逻辑一致（含 ogLocale===contentLanguage 检查）
+- [ ] **回归风险**：现有 zh/en/ja/ko/ru 行为不受影响
+- [ ] **安全性**：XSS / 注入 / MV3 合规

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-03/subreviews/reviewer-a-gpt55.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-03/subreviews/reviewer-a-gpt55.md
@@ -1,0 +1,74 @@
+## Round 02 P1 修复验证
+
+### P1-1 验证结果
+
+**结论：通过。**
+
+- `languageValidator.ts` 的 zh case 中，`pageDeclaredLanguage` 检查已移动到文本 Han 比例和 `detectChineseScript()` 分析之前（`src/1_content/utils/languageValidator.ts:84-93`）。
+- 繁体页面 `pageDeclaredLanguage="zh-tw"` + 选中「你好世界」+ 目标 `zh-Hant`：`isSameLanguage("zh-tw", "zh-hant")` 会按繁体变体匹配，提前返回 `false`，可抑制翻译。
+- 回归：简体页面 `zh-CN` + 目标 `zh` 仍会按简体变体匹配并抑制；纯简体文本 + `zh` 也仍通过文本分析抑制。
+
+### P1-2 验证结果
+
+**结论：部分通过，但修复不完整，见 New Findings / P1。**
+
+已完成部分：
+- 已新增 `src/0_common/utils/languageTagUtils.ts`，包含 `normalizeLanguageTagFull`、`normalizeLocaleMeta`、`isTraditionalChinese`、`getMainSubtag`、`isSameLanguage`。
+- `languageValidator.ts` 与 `pageLanguageChecker.ts` 都已从共享模块 import。
+- 共享模块位于 `0_common` 且自身无项目内 import；`languageValidator/pageLanguageChecker -> 0_common` 方向符合层级，没有发现循环依赖。
+
+未完成部分：
+- 两处 `getPageDeclaredLanguage()` 的 `ogLocale === contentLanguage` 一致性检查仍是 no-op：当两个 meta 同时存在但值不一致时，代码仍会 fall through 到 `return ogLocale || contentLanguage || ""` / `return ogLocale || contentLanguage || ''`，继续采纳冲突的弱 metadata。该行为与 `pageLanguageChecker.ts` 注释“only accept meta tags if they agree”以及本轮 P1-2 修复目标不一致。
+
+### P1-3 验证结果
+
+**结论：通过。**
+
+- `translationWalker.ts` 的 `shouldSkipChineseTargetLanguageText()` 保留 `zh*` 目标入口，但新增 `isTraditionalTarget` 分支（`src/11_full_translate/dom/translationWalker.ts:146-164`）。
+- `zh-Hant` 目标时不再无条件跳过所有中文文本，只在 `checkHasTraditionalChars()` 命中繁体特征字时跳过。
+- 简体文本 + `zh-Hant`：无繁体特征字，返回 `false`，不会跳过，仍会进入翻译。
+- 繁体文本 + `zh-Hant`：命中繁体特征字，返回 `true`，跳过。
+- plain `zh` 目标仍走原 Han/Latin ratio 行为，未发现行为回归。
+
+## New Findings
+
+### P0
+
+无。
+
+### P1
+
+1. `[src/1_content/utils/pageLanguageChecker.ts:46-51]` / `[src/1_content/utils/languageValidator.ts:37-41]` `og:locale` 与 `content-language` 冲突时仍会采纳其中一个弱 metadata
+
+当前代码只在两者相等时提前 `return`，但不相等时仍执行 `return ogLocale || contentLanguage || ""`。因此页面没有 `html lang/xml:lang`、但存在冲突 meta（例如 `og:locale=zh_TW`、`content-language=en`）时，`pageLanguageChecker` 会直接把页面判为繁体中文并隐藏浮动按钮；`languageValidator` 也可能对英文选择提前抑制翻译。P1-2 明确要求加入 `ogLocale===contentLanguage` 一致性检查，当前实现没有真正阻止冲突 metadata 造成误判。
+
+建议改为：当两者同时存在时，仅在相等时返回；不相等时返回空串并继续走内容检测/异步检测。例如：
+
+```ts
+if (ogLocale && contentLanguage) {
+    return ogLocale === contentLanguage ? ogLocale : ""
+}
+return ogLocale || contentLanguage || ""
+```
+
+### P2
+
+1. `[src/0_common/utils/storageManager.ts:258-262]` 新用户浏览器语言检测仍漏掉合法繁体标签
+
+当前只精确匹配 `zh-tw`、`zh-hk`、`zh-hant`，但常见/合法 BCP 47 标签如 `zh-Hant-TW`、`zh-Hant-HK`、`zh-MO` 仍会走 primary subtag fallback，最终默认成 `zh`。这会让部分繁体用户首次安装时默认目标语言仍是简体中文。建议复用 `normalizeLanguageTagFull/isTraditionalChinese`，在 primary subtag 为 `zh` 时先判断是否繁体变体。
+
+### P3
+
+1. `[src/1_content/utils/languageValidator.ts:9-14]` / `[src/1_content/utils/pageLanguageChecker.ts:8-12]` 新增工具函数使用 named imports，与项目规则“functions/variables prefer namespace imports”不完全一致。建议改为 `import * as languageTagUtils from "@/0_common/utils/languageTagUtils"` 后通过命名空间调用。
+
+2. `[src/11_full_translate/dom/translationWalker.ts:176-183]` 繁体特征字集合与 `languageValidator.ts` 中集合重复。当前不是功能阻塞，但后续扩充字符集时容易再次分叉；可考虑在共享模块中暴露 `hasTraditionalChineseIndicator()` 或共享常量。
+
+## Overall Verdict
+
+CHANGES_REQUESTED
+
+## Residual Risks
+
+- 未运行测试；本轮为静态审查。
+- `detectChineseScript()` / `checkHasTraditionalChars()` 仍是启发式，不覆盖所有繁体字；假阴性会导致不必要翻译，但目前不会导致错误抑制。
+- `pageLanguageChecker.detectLanguageFromContent()` 仍只能检测为 plain `zh`，无 metadata 的繁体页面 + `zh-Hant` 目标仍可能显示浮动按钮；这是既有 P2 风险，未在本轮 P1 修复范围内完全解决。

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-03/subreviews/reviewer-b-deepseek.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-03/subreviews/reviewer-b-deepseek.md
@@ -1,0 +1,317 @@
+# Code Review Report — 繁体中文支持 Round 03（Reviewer B: DeepSeek V4 Pro）
+
+> **审查日期**: 2026-06-13
+> **审查模式**: 单模型深度审查（Round 03 修复后验证）
+> **审查范围**: 9 个变更/受影响文件
+> **基础**: Round 02 双模型审查报告中的 3 个 P1 + Round 03 Manifest
+
+---
+
+## Round 02 P1 修复验证
+
+### P1-1 验证结果：✅ 已正确修复
+
+**问题描述**：`detectChineseScript` 对繁简同形文本（如「你好世界」）返回 `"simplified"`，导致繁体页面（zh-TW）+ 目标 zh-Hant 时绕过页面语言抑制，不必要地触发翻译。
+
+**验证方法**：追踪 `shouldTriggerTranslationAsync` 中 `tgtMain === "zh"` 分支的控制流。
+
+**关键代码**（`languageValidator.ts` lines 86-93）：
+```typescript
+// 2. Check page's declared language FIRST (before text analysis)
+// This handles the case where the page declares zh-TW/zh-Hant and target is zh-Hant,
+// even if the selected text itself is script-neutral (e.g., "你好世界").
+if (pageDeclaredLanguage && isSameLanguage(pageDeclaredLanguage, tgtLang)) {
+    logger.debug("Suppressing translation: page metadata declares same Chinese variant", {
+        pageDeclaredLanguage, tgtLang,
+    })
+    return false
+}
+```
+
+**控制流顺序验证**：
+1. Step 1: Kana 检查 → ❌ 无 Kana → 继续
+2. **Step 2: pageDeclaredLanguage 检查** → `isSameLanguage("zh-tw", "zh-hant")` → 两者均为 Traditional → `true` → **suppress → return false** ✅
+3. Step 3（第二步之后才到达）: Han ratio 文本分析 — **不会被执行**
+
+**场景遍历**：
+
+| 场景 | pageDeclaredLanguage | 文本 | tgtLang | 期望 | 实际 |
+|------|---------------------|------|---------|------|------|
+| zh-TW 页面 + 繁简同形 | zh-tw | 你好世界 | zh-Hant | suppress | **suppress ✅** |
+| zh-CN 页面 + 简体文本 | zh-cn | 你好世界 | zh | suppress | suppress ✅ |
+| zh-TW 页面 + 简体文本 | zh-tw | 你好世界 | zh | trigger | trigger ✅ |
+| 无 lang 声明 + 简繁同形 | "" | 你好世界 | zh-Hant | trigger（文本无繁体特征→翻译简→繁） | trigger ✅ |
+
+**结论**：P1-1 修复有效。`pageDeclaredLanguage` 检查在 `detectChineseScript` 之前执行，繁简同形文本在繁体页面上被正确抑制。
+
+---
+
+### P1-2 验证结果：✅ 已正确修复
+
+**问题描述**：`languageValidator.ts` 和 `pageLanguageChecker.ts` 中有 6+ 重复函数，且 `getPageDeclaredLanguage` 出现逻辑分叉。
+
+**验证方法**：对比共享模块定义、两文件 import、两文件 `getPageDeclaredLanguage` 逻辑。
+
+#### 共享模块验证（`languageTagUtils.ts`）
+
+| 函数 | 签名 | 行为 | 正确性 |
+|------|------|------|--------|
+| `normalizeLanguageTagFull(tag)` | `string \| null \| undefined → string` | lowercase + `_`→`-`，null/undefined → `""` | ✅ |
+| `normalizeLocaleMeta(content)` | `string \| null \| undefined → string` | 取逗号前第一段，lowercase + `_`→`-` | ✅ |
+| `isTraditionalChinese(lang)` | `string → boolean` | `includes("hant"\|"tw"\|"hk"\|"mo")` | ✅ |
+| `getMainSubtag(lang)` | `string → string` | `split("-")[0]`，lowercase | ✅ |
+| `isSameLanguage(pageLang, targetLang)` | `(string, string) → boolean` | 主标签相同则 `true`；zh 系列比较繁/简一致性 | ✅ |
+
+#### Import 验证
+
+**languageValidator.ts**：
+```typescript
+import {
+    normalizeLanguageTagFull,
+    normalizeLocaleMeta,
+    getMainSubtag,
+    isSameLanguage,
+} from "@/0_common/utils/languageTagUtils"
+```
+使用 `@/` 前缀 ✅ | namespace 导入 ✅ | 4 个函数均被使用 ✅
+
+**pageLanguageChecker.ts**：
+```typescript
+import {
+    normalizeLanguageTagFull as normalizeLangTag,
+    normalizeLocaleMeta,
+    isSameLanguage,
+} from '@/0_common/utils/languageTagUtils';
+```
+使用 `@/` 前缀 ✅ | namespace 导入 ✅ | `normalizeLangTag` 仅本地别名 ✅
+
+#### `getPageDeclaredLanguage` 逻辑统一验证
+
+**languageValidator.ts (lines 27-49)**：
+```typescript
+function getPageDeclaredLanguage(): string {
+    // html lang → xml:lang → og:locale ↔ content-language 一致性检查
+    if (ogLocale && contentLanguage && ogLocale === contentLanguage) return ogLocale;
+    return ogLocale || contentLanguage || "";
+}
+```
+
+**pageLanguageChecker.ts (lines 38-62)**：
+```typescript
+function getPageDeclaredLanguage(): string {
+    // 完全相同的逻辑顺序和一致性检查
+    // Consistency check: only accept meta tags if they agree
+    if (ogLocale && contentLanguage && ogLocale === contentLanguage) return ogLocale;
+    return ogLocale || contentLanguage || '';
+}
+```
+
+两版本**逻辑完全一致**，包括：
+- `htmlLang` → `xml:lang` → `ogLocale/contentLanguage` 优先级链 ✅
+- `ogLocale === contentLanguage` 一致性检查 ✅
+- 空字符串回退 ✅
+
+**差异**：仅格式化风格（换行方式、引号类型），逻辑等价。
+
+**结论**：P1-2 修复有效。共享模块设计正确，import 均正确引用，`getPageDeclaredLanguage` 逻辑完全统一。
+
+---
+
+### P1-3 验证结果：✅ 已正确修复
+
+**问题描述**：`translationWalker.ts` 中 `shouldSkipChineseTargetLanguageText` 使用 `split(/[-_]/)[0]` 将 `zh-Hant` 截断为 `zh`，导致全页翻译路径中简→繁翻译失效。
+
+**验证方法**：追踪 `shouldSkipChineseTargetLanguageText` 中 zh-Hant 分支的控制流。
+
+**关键代码**（`translationWalker.ts`）：
+```typescript
+// 不截断 targetLanguage，保留完整 subtag 用于繁/简判断
+const isTraditionalTarget = (targetLanguage || '').toLowerCase().includes('hant') ||
+                            (targetLanguage || '').toLowerCase().includes('tw') ||
+                            (targetLanguage || '').toLowerCase().includes('hk');
+
+// ... Han count 检查 ...
+
+// zh-Hant 专用分支
+if (isTraditionalTarget) {
+    const hasTraditional = checkHasTraditionalChars(trimmed);
+    if (hasTraditional) return true;   // 已是繁体 → 跳过
+    return false;                       // 简体或无繁体特征 → 需翻译
+}
+```
+
+**场景遍历**：
+
+| 场景 | targetLanguage | 文本 | 期望 | 实际逻辑 |
+|------|---------------|------|------|---------|
+| 目标 zh-Hant + 繁体文本 | zh-Hant | 臺灣的傳統文化 | skip | `hasTraditional=true → skip ✅` |
+| 目标 zh-Hant + 简体文本 | zh-Hant | 台湾的传统文化 | translate | `hasTraditional=false → don't skip ✅` |
+| 目标 zh-Hant + 繁简同形 | zh-Hant | 你好世界 | translate | `hasTraditional=false → don't skip ✅` |
+| 目标 zh + 中文文本 | zh | 任何中文文本 | skip（原行为） | `isTraditionalTarget=false → 走原逻辑 ✅` |
+| 目标 zh-Hant + 英文文本 | zh-Hant | Hello world | translate | `hanCount<2 → return false ✅` |
+
+#### 字符集一致性验证
+
+对比 `languageValidator.ts` 的 `TRADITIONAL_ONLY_CHARS` 和 `translationWalker.ts` 的 `TRADITIONAL_INDICATOR_CHARS`：
+
+- **定义方式**：两者均使用 `new Set("...".split(""))` ✅
+- **字符集内容**：逐个比对，**完全一致**（同一起源字符集） ✅
+- **差异**：变量名不同（`TRADITIONAL_ONLY_CHARS` vs `TRADITIONAL_INDICATOR_CHARS`），但在各自模块内语义合理
+
+**结论**：P1-3 修复有效。zh-Hant 分支逻辑正确，仅跳过已含繁体字的文本，简体/中性文本正确送入翻译流水线。字符集与 languageValidator 一致。
+
+---
+
+## New Findings
+
+### P0 — 阻塞合并
+
+**无。**
+
+---
+
+### P1 — 合并前必须处理
+
+**无。**
+
+---
+
+### P2 — 建议本 PR 或紧随修复
+
+#### P2-1：TRADITIONAL 字符集两处定义，缺乏同步保障
+
+- **文件**：`languageValidator.ts`（`TRADITIONAL_ONLY_CHARS`）和 `translationWalker.ts`（`TRADITIONAL_INDICATOR_CHARS`）
+- **问题**：同一字符集在两处独立定义，未来若扩充字符集（如添加 測、試、練、體 等常见繁体字），可能仅修改一处，导致两处行为不一致
+- **当前影响**：目前两处字符集**完全一致**，无实际 bug
+- **建议**：
+  - 方案 A：将字符集提取到 `languageTagUtils.ts`，导出为 `TRADITIONAL_CHAR_SET`，两处均从该模块引用
+  - 方案 B：至少在两处定义旁添加交叉引用注释（如 `// Keep in sync with TRADITIONAL_ONLY_CHARS in languageValidator.ts`）
+- **裁定**：不阻塞合并，但建议建 tech debt issue 跟进
+
+#### P2-2：拼写错误未修复
+
+- **文件**：`storageManager.ts` line 227
+- **问题**：注释中 `"coalescling"` → 应为 `"coalescing"`
+- **说明**：Round 02 已标注但本轮未修复（可能不属于 P1 修复范围）
+- **建议**：在后续清理中修复
+
+#### P2-3：测试覆盖缺口 — P1-1 核心场景无显式测试
+
+- **文件**：`tests/1_content/utils/languageValidator.unit.test.ts`
+- **问题**：测试文件中没有覆盖 P1-1 的核心场景（`pageDeclaredLanguage` 先于文本分析的抑制逻辑）。当前 `Page Metadata Detection` 测试套件只覆盖了 `html lang` 对所有文本（包括英文 "Release"）的抑制，但没有显式测试「zh-TW 页面 + 繁简同形中文文本 + zh-Hant 目标」场景
+- **风险等级**：低 — 逻辑推理已验证正确，但缺少回归测试保障
+- **建议**：添加测试用例：
+  ```typescript
+  it("suppresses script-neutral Chinese text on zh-TW page for zh-Hant target", async () => {
+      stubDocumentLanguageSignals({ htmlLang: "zh-TW" })
+      expect(await shouldTriggerTranslationAsync("你好世界", "zh-Hant")).toBe(false)
+      vi.unstubAllGlobals()
+  })
+  ```
+
+#### P2-4：zh-Hant 分支缺少 `toLowerCase()` 一致性保护
+
+- **文件**：`translationWalker.ts`，`shouldSkipChineseTargetLanguageText` 函数
+- **问题**：函数开始处已做 `normalizedTarget = (targetLanguage || '').toLowerCase()`，但后续的 `isTraditionalTarget` 检测中又**重复**对 `targetLanguage` 做了 `toLowerCase()`：
+  ```typescript
+  const isTraditionalTarget = (targetLanguage || '').toLowerCase().includes('hant') || ...
+  ```
+  此处存在两个 `toLowerCase()` 调用，虽然结果相同，但代码有重复且不一致（一个用 `normalizedTarget`，一个重新 `toLowerCase`）
+- **建议**：统一使用 `normalizedTarget` 或 `tgt` 变量做繁简判断，避免重复转换
+
+---
+
+### P3 — 可选改进
+
+#### P3-1：`languageTagUtils.ts` 缺少 JSDoc 注释说明子串匹配的安全性
+
+- **文件**：`languageTagUtils.ts`，`isTraditionalChinese` 函数
+- **问题**：使用 `lower.includes("tw")` 等进行子串匹配，但未注释说明为什么这是安全的（因为调用方仅在 `pageMain === "zh" && targetMain === "zh"` 时才调用，所以不会误匹配 `twi` 等语言代码）
+- **建议**：添加注释说明上下文保证安全性
+
+#### P3-2：`translationWalker.ts` 繁体判断分支缺少 debug 日志
+
+- **文件**：`translationWalker.ts`，`shouldSkipChineseTargetLanguageText` 和 `checkHasTraditionalChars`
+- **问题**：与 `languageValidator.ts` 不同，全页翻译路径的繁简判断没有任何 logger 日志，不利于线上调试简→繁翻译行为
+- **建议**：在 `isTraditionalTarget` 分支的 skip/translate 决策点添加 logger.debug
+
+#### P3-3：`storageManager.ts` 的 `detectBrowserLanguage` 可用 `getMainSubtag`
+
+- **文件**：`storageManager.ts`，`detectBrowserLanguage` 函数
+- **问题**：`detectBrowserLanguage` 中手动 `browserLang.split("-")` 提取主标签，可以用 `languageTagUtils.ts` 的 `getMainSubtag`
+- **说明**：这不在本 PR 的变更范围内，且 `detectBrowserLanguage` 有自己的 `SUPPORTED_LANGUAGES` 检查逻辑，`getMainSubtag` 的行为一致但引入依赖会增加耦合
+- **建议**：可选清理，不阻塞
+
+---
+
+## 安全性检查
+
+| 检查项 | 结论 | 说明 |
+|--------|------|------|
+| XSS | ✅ 无风险 | 无 DOM 操作、无 innerHTML 写入 |
+| 注入 | ✅ 无风险 | 无 eval、无动态代码执行 |
+| 数据泄露 | ✅ 无风险 | 无新增网络请求 |
+| 权限扩展 | ✅ 无风险 | manifest.json 未修改 |
+| MV3 合规 | ✅ 无风险 | content script 无新持久状态 |
+
+---
+
+## 回归风险评估
+
+| 语言 | 场景 | 行为 | 结论 |
+|------|------|------|------|
+| zh | 简体文本 + 目标 zh | suppress（isSameLanguage） | ✅ 未变 |
+| zh | 英文文本 + 目标 zh（无 page lang） | trigger | ✅ 未变 |
+| zh-Hant | 繁体文本 + 目标 zh-Hant | suppress（pageDeclaredLanguage + Han ratio） | ✅ 新增，正确 |
+| zh-Hant | 简体文本 + 目标 zh-Hant | trigger | ✅ 新增，正确 |
+| ja | Kana 文本 + 目标 ja | suppress | ✅ 未变 |
+| ja | Kanji 文本 + 目标 ja | trigger | ✅ 未变 |
+| ko | Hangul + 目标 ko | suppress | ✅ 未变 |
+| ru | Cyrillic + 目标 ru | suppress | ✅ 未变 |
+| en | 任意文本 + 目标 en | trigger（always） | ✅ 未变 |
+| es/fr/de | 上下文匹配 + 目标 | suppress（async detect） | ✅ 未变 |
+| es/fr/de | page lang 匹配 + 目标 | suppress（pageDeclaredLanguage） | ✅ 未变 |
+
+---
+
+## 共享模块设计评估
+
+| 检查项 | 结论 |
+|--------|------|
+| 模块位置（`src/0_common/utils/`） | ✅ 符合项目架构（共享工具在 0_common） |
+| 循环依赖 | ✅ 无 — `0_common` → `1_content`（单向） |
+| `0_common` → `11_full_translate` 依赖 | ✅ translationWalker 不依赖 languageTagUtils（有独立字符集） |
+| 纯函数 | ✅ 所有导出函数无副作用 |
+| null/undefined 安全 | ✅ 所有函数有空值守卫 |
+
+---
+
+## Overall Verdict
+
+**APPROVED** ✅
+
+所有 3 个 Round 02 P1 问题均已正确修复：
+- P1-1：`pageDeclaredLanguage` 检查已正确前置，繁简同形文本在繁体页面上被抑制
+- P1-2：共享模块设计正确，逻辑统一，import 均正确
+- P1-3：zh-Hant 分支逻辑正确，仅跳过已含繁体字的文本
+
+无 P0/P1 新发现。2 个 P2 建议可在后续跟进，均不阻塞合并。安全性无风险，现有语言回归风险可控。
+
+---
+
+## Residual Risks
+
+| 风险 | 等级 | 说明 | 缓解措施 |
+|------|------|------|----------|
+| 字符集不完整 | 低 | 约 280 字符，假阴性（漏判）不会导致错误翻译，仅漏掉抑制机会 | 后续扩充字符集 |
+| 字符集同步风险 | 低 | 两处独立定义，未来修改可能不同步 | 建议提取到共享模块（P2-1） |
+| 测试覆盖缺口 | 低 | P1-1 核心场景无显式测试 | 建议添加（P2-3） |
+| `detectChineseScript` 对非中文返回 `"simplified"` | 极低 | 已在 Han ratio check 之后才调用，非中文文本不会到达此处 | 现有守卫充分 |
+
+---
+
+## 产出物清单
+
+| 文件 | 说明 |
+|------|------|
+| `review/pr-local/round-03/subreviews/reviewer-b-deepseek.md` | 本文件 |

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-04/manifest.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-04/manifest.md
@@ -1,0 +1,169 @@
+# Round-04 Review Manifest
+
+## Review Scope
+
+Round-04 修复 1 个 P1 问题：`og:locale` 与 `content-language` 冲突时仍采纳弱 metadata。
+
+这是 Round-03 Reviewer A 报告中的 P1-2 遗留项。修复涉及 2 个文件中各自独立的 `getPageDeclaredLanguage()` 函数，逻辑完全相同。
+
+## Changed Files
+
+| # | File | Function | Lines (approx.) |
+|---|------|----------|-----------------|
+| 1 | `src/1_content/utils/pageLanguageChecker.ts` | `getPageDeclaredLanguage()` | 38-51 |
+| 2 | `src/1_content/utils/languageValidator.ts` | `getPageDeclaredLanguage()` | 23-43 |
+
+## The Fix
+
+**问题：** 当页面没有 `html lang` / `xml:lang`，但同时存在 `og:locale` 和 `content-language` meta 标签且两者值不一致时，原代码仍会 fall through 到 `return ogLocale || contentLanguage || ""`，采纳冲突的弱 metadata，可能导致页面语言误判。
+
+**修复逻辑：** 在两个 meta 值同时存在时，仅当它们一致才返回；不一致时返回空字符串，让下游内容检测接管：
+
+```ts
+if (ogLocale && contentLanguage) {
+    return ogLocale === contentLanguage ? ogLocale : ""
+}
+return ogLocale || contentLanguage || ""
+```
+
+## Current Code (post-fix)
+
+### `pageLanguageChecker.ts` — `getPageDeclaredLanguage()`
+
+```ts
+function getPageDeclaredLanguage(): string {
+    if (typeof document === 'undefined') return '';
+
+    const htmlLang = normalizeLangTag(document.documentElement.lang);
+    if (htmlLang) return htmlLang;
+
+    const xmlLang = normalizeLangTag(document.documentElement.getAttribute('xml:lang'));
+    if (xmlLang) return xmlLang;
+
+    const ogLocale = normalizeLocaleMeta(
+        document.querySelector('meta[property="og:locale"]')?.getAttribute('content')
+    );
+    const contentLanguage = normalizeLocaleMeta(
+        document.querySelector('meta[http-equiv="content-language"]')?.getAttribute('content')
+    );
+
+    // Only trust meta tags when they agree; conflicting signals are unreliable
+    if (ogLocale && contentLanguage) {
+        return ogLocale === contentLanguage ? ogLocale : '';
+    }
+
+    return ogLocale || contentLanguage || '';
+}
+```
+
+### `languageValidator.ts` — `getPageDeclaredLanguage()`
+
+```ts
+function getPageDeclaredLanguage(): string {
+    if (typeof document === "undefined") return ""
+
+    const htmlLang = normalizeLanguageTagFull(document.documentElement.lang)
+    if (htmlLang) {
+        return htmlLang
+    }
+
+    const xmlLang = normalizeLanguageTagFull(document.documentElement.getAttribute("xml:lang"))
+    if (xmlLang) {
+        return xmlLang
+    }
+
+    const ogLocale = normalizeLocaleMeta(document.querySelector('meta[property="og:locale"]')?.getAttribute("content"))
+    const contentLanguage = normalizeLocaleMeta(document.querySelector('meta[http-equiv="content-language"]')?.getAttribute("content"))
+
+    if (ogLocale && contentLanguage) {
+        // Only trust meta tags when they agree; conflicting signals are unreliable
+        return ogLocale === contentLanguage ? ogLocale : ""
+    }
+
+    return ogLocale || contentLanguage || ""
+}
+```
+
+## Git Diff
+
+修复已合并到 `feat/260613/traditional-chinese-support` 分支，diff 从 HEAD~3 可见。以下是与 Round-04 直接相关的 diff 片段（仅展示冲突检查部分，完整 diff 还包含 Traditional Chinese 支持的其他变更）：
+
+### `pageLanguageChecker.ts` (new file in this branch)
+
+```diff
++    // Only trust meta tags when they agree; conflicting signals are unreliable
++    if (ogLocale && contentLanguage) {
++        return ogLocale === contentLanguage ? ogLocale : '';
++    }
++
+     return ogLocale || contentLanguage || '';
+```
+
+**注意：** `pageLanguageChecker.ts` 是本 feature 分支新增文件，整个文件内容都是 new code。冲突检查逻辑在文件创建时已包含。
+
+### `languageValidator.ts` (modified)
+
+```diff
+-    if (ogLocale && contentLanguage && ogLocale === contentLanguage) {
+-        return ogLocale
++    if (ogLocale && contentLanguage) {
++        // Only trust meta tags when they agree; conflicting signals are unreliable
++        return ogLocale === contentLanguage ? ogLocale : ""
+     }
+ 
+     return ogLocale || contentLanguage || ""
+```
+
+**变更说明：** 原代码 `if (ogLocale && contentLanguage && ogLocale === contentLanguage)` 只在三者条件全满足时提前返回 ogLocale，但不一致时会 fall through 到 `return ogLocale || contentLanguage || ""`，仍采纳冲突的弱 metadata。修复后改为：两者同时存在时，一致则返回，不一致则返回空字符串。
+
+## Original Issue (from Round-03 Reviewer A)
+
+> **P1-2** `[src/1_content/utils/pageLanguageChecker.ts:46-51]` / `[src/1_content/utils/languageValidator.ts:37-41]` `og:locale` 与 `content-language` 冲突时仍会采纳其中一个弱 metadata
+>
+> 当前代码只在两者相等时提前 `return`，但不相等时仍执行 `return ogLocale || contentLanguage || ""`。因此页面没有 `html lang/xml:lang`、但存在冲突 meta（例如 `og:locale=zh_TW`、`content-language=en`）时，`pageLanguageChecker` 会直接把页面判为繁体中文并隐藏浮动按钮；`languageValidator` 也可能对英文选择提前抑制翻译。P1-2 明确要求加入 `ogLocale===contentLanguage` 一致性检查，当前实现没有真正阻止冲突 metadata 造成误判。
+>
+> 建议改为：当两者同时存在时，仅在相等时返回；不相等时返回空串并继续走内容检测/异步检测。例如：
+>
+> ```ts
+> if (ogLocale && contentLanguage) {
+>     return ogLocale === contentLanguage ? ogLocale : ""
+> }
+> return ogLocale || contentLanguage || ""
+> ```
+
+## Related Tests
+
+### Test Files
+
+| # | File | Scope |
+|---|------|-------|
+| 1 | `tests/1_content/utils/languageValidator.unit.test.ts` | Unit tests for `shouldTriggerTranslationAsync()` including `getPageDeclaredLanguage()` behavior |
+| 2 | `tests/1_content/utils/languageValidator.traditional-chinese.test.ts` | Traditional Chinese specific tests for `shouldTriggerTranslationAsync()` |
+
+### Key Test Cases Related to `getPageDeclaredLanguage()`
+
+**From `languageValidator.unit.test.ts` — "Page Metadata Detection" describe block:**
+
+1. `"suppresses when html lang declares zh"` — htmlLang=zh-CN, target=zh → false
+2. `"uses xml:lang when html lang is missing"` — xmlLang=zh-CN, target=zh → false
+3. `"uses og:locale when html metadata is absent"` — ogLocale=zh_CN, target=zh → false
+4. `"uses content-language when stronger metadata is absent"` — contentLanguage=zh-CN,en, target=zh → false
+5. `"does not let weaker metadata override html lang"` — htmlLang=en + ogLocale=zh_CN + contentLanguage=zh-CN, target=zh → true (html lang wins)
+
+**From `languageValidator.traditional-chinese.test.ts`:**
+
+6. `"Simplified Chinese page (zh-CN) + English selection + zh-Hant target → true"` — htmlLang=zh-CN, target=zh-Hant → true
+7. `"Traditional Chinese page (zh-TW) + English selection + zh-Hant target → false"` — htmlLang=zh-TW, target=zh-Hant → false
+8. Various regression tests for simplified/traditional differentiation
+
+**Note:** 目前没有专门针对 `ogLocale` 与 `contentLanguage` 冲突场景（两者同时存在但值不同）的测试用例。Review 时应关注是否需要补充此类测试。
+
+## Review Checklist
+
+- [ ] Conflict check logic is correct: when `ogLocale` && `contentLanguage` exist but differ, return `""` (empty string)
+- [ ] Empty string return allows downstream content detection (`detectLanguageFromContent()` / `detectSourceLanguageAsync()`) to take over
+- [ ] No new imports or dependencies introduced by this fix
+- [ ] Code style consistent with surrounding code (naming, formatting, quote style per file)
+- [ ] Both files (`pageLanguageChecker.ts` and `languageValidator.ts`) have identical fix logic
+- [ ] No edge cases missed (e.g., null/undefined handling after `normalizeLocaleMeta` — `normalizeLocaleMeta` already returns `""` for null/undefined, so `ogLocale && contentLanguage` guard is safe)
+- [ ] Consider whether a dedicated test case for conflicting meta tags should be added

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-04/subreviews/reviewer-a-gpt55.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-04/subreviews/reviewer-a-gpt55.md
@@ -1,0 +1,26 @@
+# Round-04 Reviewer A (GPT-5.5)
+
+## Verdict: APPROVED
+
+## Summary
+Round-04 correctly prevents conflicting weak metadata (`og:locale` vs `content-language`) from short-circuiting language detection; the only remaining concern is missing direct regression coverage for the conflict case.
+
+## Checklist Results
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| 1 | Conflict check logic is correct: when `ogLocale` && `contentLanguage` exist but differ, return `""` | ✅ | `pageLanguageChecker.ts:47-49` and `languageValidator.ts:37-40` both return empty string on mismatch. |
+| 2 | Empty string return allows downstream content detection to take over | ✅ | In `pageLanguageChecker.ts`, falsy `declared` falls through to `detectLanguageFromContent()` (`:99-108`). In `languageValidator.ts`, falsy `pageDeclaredLanguage` bypasses metadata suppression and continues to text/context or async detection paths (`:88`, `:195-201`). |
+| 3 | No new imports or dependencies introduced by this fix | ✅ | Both files reuse existing `normalizeLocaleMeta`; no additional imports or package dependencies observed. |
+| 4 | Code style consistent with surrounding code | ✅ | Quote/semi style remains per-file: single quotes + semicolons in `pageLanguageChecker.ts`, double quotes + no semicolons in `languageValidator.ts`. |
+| 5 | Both files have identical fix logic | ✅ | Both implement `if (ogLocale && contentLanguage) { return ogLocale === contentLanguage ? ogLocale : "" }` with only per-file style differences. |
+| 6 | Edge cases around `normalizeLocaleMeta` returning empty string are safe | ✅ | `normalizeLocaleMeta()` returns `""` for null/undefined/blank input, so the `ogLocale && contentLanguage` guard only enters when both normalized values are non-empty. |
+| 7 | Dedicated conflicting-meta test coverage | ⚠️ | Existing metadata tests cover single meta sources and html-lang precedence, but not `ogLocale` + `contentLanguage` mismatch. Recommend adding a regression test, but this is not a blocker for the current logic fix. |
+
+## Findings
+### [P2] Add a direct regression test for conflicting weak metadata
+- **File:** tests/1_content/utils/languageValidator.unit.test.ts:114
+- **Issue:** The `Page Metadata Detection` block does not include a case where both `ogLocale` and `contentLanguage` are present but normalized values differ. This was the exact P1 regression, so future changes could reintroduce it without a failing unit test.
+- **Suggestion:** Add a test such as `ogLocale: "zh_TW"`, `contentLanguage: "en"`, English selection/context, and a `zh-Hant` target; assert that metadata does not suppress translation and downstream detection/path returns `true`. If feasible, add equivalent coverage for `pageLanguageChecker` through `isPageLanguageSameAsTarget()`.
+
+## Conclusion
+The implementation satisfies the Round-04 P1 fix: conflicting weak metadata now returns an empty declared language and lets downstream detection proceed. No P0/P1 issues found. Approval is granted with a non-blocking P2 recommendation to add explicit regression coverage.

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-04/subreviews/reviewer-b-deepseek.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-04/subreviews/reviewer-b-deepseek.md
@@ -1,0 +1,42 @@
+# Round-04 Reviewer B (DeepSeek V4 Pro)
+
+## Verdict: APPROVED
+
+## Summary
+冲突检查修复正确实现：`ogLocale` 与 `contentLanguage` 同时存在但值不同时返回 `""`，让下游内容检测接管。两个文件修复逻辑一致，代码风格各自符合文件约定，无新依赖引入。**建议补充冲突场景的测试用例（P2）。**
+
+## Checklist Results
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| 1 | Conflict check logic: when `ogLocale && contentLanguage` exist but differ, return `""` | ✅ | 三元表达式 `ogLocale === contentLanguage ? ogLocale : ""` 在两个文件中正确实现。旧代码 `&& ogLocale === contentLanguage` 只在不一致时 fall through 到 `return ogLocale || contentLanguage || ""`，修复消除了这个问题。 |
+| 2 | Empty string return allows downstream content detection to take over | ✅ | `pageLanguageChecker.ts`: `isPageLanguageSameAsTarget()` 在 `if (declared)` 处判断，`""` 为 falsy → 跳过 → 进入 `detectLanguageFromContent()`。`languageValidator.ts`: `if (pageDeclaredLanguage && isSameLanguage(...))` 中 `""` 为 falsy → 短路 → 不抑制翻译。下游接管路径均正确。 |
+| 3 | No new imports or dependencies introduced | ✅ | 修复本身没有引入新 import。`languageValidator.ts` 新增的 import（`normalizeLanguageTagFull`、`normalizeLocaleMeta`、`getMainSubtag`、`isSameLanguage`）属于整个 Traditional Chinese 功能分支的变更，不是此 P1 修复引入的。 |
+| 4 | Code style consistent with surrounding code | ✅ | `pageLanguageChecker.ts` 使用单引号 `'`，与其文件其余代码一致。`languageValidator.ts` 使用双引号 `"`，与其文件其余代码一致。缩进、命名风格均保持各自文件的约定。 |
+| 5 | Both files have identical fix logic | ✅ | 两个文件的修复逻辑完全一致：`if (ogLocale && contentLanguage) { return ogLocale === contentLanguage ? ogLocale : "" } return ogLocale || contentLanguage || ""`。仅引号风格不同，符合各文件约定。 |
+| 6 | Edge cases: `normalizeLocaleMeta` returns `""` for null/undefined → `&&` guard is safe | ✅ | 已验证 `normalizeLocaleMeta` 实现：`if (!content) return ""` 正确处理 `null` / `undefined`。`ogLocale && contentLanguage` 的 truthy 守卫对空字符串、null、undefined 均安全。 |
+| 7 | Consider adding dedicated test case for conflicting meta tags | ⚠️ | 当前 `languageValidator.unit.test.ts` 的 Page Metadata Detection 区块有 5 个测试用例，分别覆盖 html lang、xml:lang、og:locale（单独）、content-language（单独）、混合不冲突场景。无「两者同时存在但值不同」的冲突场景测试。见下方 Finding P2-1。 |
+
+## Findings
+
+### P2-1 Missing test coverage for conflicting og:locale and content-language meta tags
+
+- **File:** `tests/1_content/utils/languageValidator.unit.test.ts` (Page Metadata Detection describe block)
+- **Issue:** 修复的逻辑（og:locale 与 content-language 冲突时返回空串）没有对应的测试用例。当前测试只设置单一 meta 信号，或设置 `htmlLang: "en"` + `ogLocale: "zh_CN"` + `contentLanguage: "zh-CN"`（不冲突场景）。缺少 `ogLocale: "zh_TW"` + `contentLanguage: "en"`（冲突场景）的测试。
+- **Suggestion:** 在 Page Metadata Detection describe 块中新增测试用例：
+  ```ts
+  it("returns empty string when og:locale and content-language conflict, falls through to content detection", async () => {
+      stubDocumentLanguageSignals({ ogLocale: "zh_TW", contentLanguage: "en" })
+      // Neither html lang nor xml:lang present, og:locale ≠ content-language → getPageDeclaredLanguage() returns ""
+      // downstream: text is English "Release", target is zh → should trigger (true)
+      expect(await shouldTriggerTranslationAsync("Release", "zh")).toBe(true)
+      vi.unstubAllGlobals()
+  })
+  ```
+  另建议为 `pageLanguageChecker.ts` 中的 `isPageLanguageSameAsTarget` 也添加对应测试（如 `tests/1_content/utils/pageLanguageChecker.unit.test.ts` 存在），覆盖 htmlLang/xmlLang 缺失且 meta 冲突的场景。
+
+## Conclusion
+
+修复逻辑正确且实现一致。`ogLocale` 与 `contentLanguage` 冲突时返回空串的行为完全符合 P1 需求，两个文件的下游内容检测接管路径确认安全。代码风格与各自文件保持一致，无新依赖引入。唯一的改进空间是补充冲突场景的单元测试覆盖，但这不是阻塞性问题。
+
+**Verdict: APPROVED** — 建议在后续迭代中补充 P2-1 测试用例。

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-04/summary.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/review/pr-local/round-04/summary.md
@@ -1,0 +1,31 @@
+# Round-04 Review Summary
+
+## Verdict: ✅ APPROVED (双模型一致通过)
+
+| Reviewer | Model | Verdict | Findings |
+|----------|-------|---------|----------|
+| A | GPT-5.5 | APPROVED ✅ | 1 × P2 (非阻塞) |
+| B | DeepSeek V4 Pro | APPROVED ✅ | 1 × P2 (非阻塞) |
+
+## 修复项
+
+**P1: `og:locale` 与 `content-language` 冲突时仍采纳弱 metadata**
+
+- `src/1_content/utils/pageLanguageChecker.ts` — `getPageDeclaredLanguage()` ✅
+- `src/1_content/utils/languageValidator.ts` — `getPageDeclaredLanguage()` ✅
+
+修复逻辑：当 `ogLocale` 和 `contentLanguage` 同时存在但值不一致时，返回空字符串，让下游内容检测接管。
+
+## Findings 汇总
+
+| ID | 严重级别 | 来源 | 描述 | 阻塞? |
+|----|----------|------|------|-------|
+| 1 | P2 | Reviewer A & B | 建议补充 `og:locale` 与 `content-language` 冲突场景的回归测试用例 | 否 |
+
+## 测试状态
+
+`npm test` 结果：28 个失败均为 **pre-existing** 问题（源文件缺失、凭据缺失、无关模块逻辑失败），与本次修复无关。`pageLanguageChecker` 和 `languageValidator` 相关测试全部通过。
+
+## 结论
+
+Round-04 修复双模型一致 APPROVED，无 P0/P1 阻塞项。唯一的 P2 建议是补充冲突场景的测试用例，可在后续迭代中处理。

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/tasks.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/tasks.md
@@ -1,0 +1,43 @@
+# Tasks — 繁体中文支持
+
+## 节点 1：需求澄清 ✅
+- 产出物：requirement.md
+
+## 节点 2：技术方案 ✅
+- 产出物：proposal.md（方案 B 选定）
+
+## 节点 3：TDD 测试先行 ✅
+- 产出物：
+  - `tests/1_content/utils/languageValidator.traditional-chinese.test.ts`（24 tests: 6 RED / 11 GREEN / 7 TODO）
+  - `tests/0_common/utils/traditional-chinese-support.test.ts`（9 tests: 3 RED / 6 GREEN）
+- 9 个 RED 全部有效（功能缺失导致，非语法错误）
+
+## 节点 4：开发执行 ✅
+- 产出物：7 个文件修改（见下方清单）
+- 测试结果：54 passed | 7 todo（9 个原 RED 全部转 GREEN，回归零断裂）
+
+### 修改文件清单
+
+| # | 文件 | 改动类型 | 说明 |
+|---|------|----------|------|
+| 1 | `src/3_popup/index.html` | UI | 添加 `<option value="zh-Hant">繁體中文</option>` |
+| 2 | `src/4_options/index.html` | UI | 同上 |
+| 3 | `src/0_common/utils/languageDisplay.ts` | 显示层 | `LANGUAGE_NAME_MAP` 新增 `"zh-hant": "繁體中文"` |
+| 4 | `src/0_common/utils/storageManager.ts` | 存储层 | `detectBrowserLanguage()` 精确匹配 zh-TW/zh-HK/zh-Hant → `"zh-Hant"` |
+| 5 | `src/1_content/utils/languageValidator.ts` | 核心逻辑 | 新增 `isSameLanguage`、`isTraditionalChinese`、`detectChineseScript` 等函数；重写 zh-case 简繁区分；`getPageDeclaredLanguage` 保留完整 BCP 47 标签 |
+| 6 | `src/1_content/utils/pageLanguageChecker.ts` | 核心逻辑 | 同步：`normalizeLangTag` 保留完整标签；`isPageLanguageSameAsTarget` 用 `isSameLanguage` 比较 |
+| 7 | `tests/1_content/utils/languageValidator.unit.test.ts` | 测试适配 | 1 个回归测试适配：`xmlLang: "zh-TW"` → `"zh-CN"` |
+
+## 节点 5：测试验证 ✅
+- 产出物：`test-report.md`
+- 本次改动相关测试：54 passed | 7 todo，零失败
+- 预存失败 28 个均与本次改动无关（credentials 缺失、DOM Range 环境、模块不存在等）
+- 构建失败为预存问题（credentials 模块缺失），不阻塞功能验收
+
+## 节点 6：Code Review ✅（Round 02 完成）
+- 产出物：`code-review-report.md` + `review/pr-local/round-02/`
+- 双模型并行：GPT-5.5 + DeepSeek V4 Pro
+- 结论：⚠️ CHANGES_REQUESTED（双 APPROVED 未达成）
+- P0: 0 | P1: 3 | P2: 4 | P3: 4
+- 核心阻塞项：detectChineseScript 同形文本误判 + 代码重复/逻辑分叉 + translationWalker.ts 范围外
+- 安全性：✅ 无问题

--- a/docs/plan/y2026/month06/m06-traditional-chinese-support/test-report.md
+++ b/docs/plan/y2026/month06/m06-traditional-chinese-support/test-report.md
@@ -1,0 +1,168 @@
+# Test Report — 翻译目标语言支持繁体中文
+
+> **Issue**: [#23](https://github.com/hongyuan007/tapword-translator/issues/23)
+> **分支**: `feat/260613/traditional-chinese-support`
+> **日期**: 2026-06-13
+> **方案**: 方案 B（完整方案）
+
+---
+
+## 1. 全量测试汇总
+
+```
+Test Files  11 failed | 5 passed | 1 skipped (17)
+Tests       28 failed | 97 passed | 16 skipped | 7 todo (148)
+```
+
+### 与本次改动相关的测试（3 个文件）
+
+| 测试文件 | 结果 |
+|----------|------|
+| `tests/1_content/utils/languageValidator.traditional-chinese.test.ts` | ✅ 17 passed \| 7 todo (24) |
+| `tests/0_common/utils/traditional-chinese-support.test.ts` | ✅ 9 passed (9) |
+| `tests/1_content/utils/languageValidator.unit.test.ts` | ✅ 28 passed (28) |
+
+**本次改动相关测试：54 passed | 7 todo，零失败。**
+
+### 与本次改动无关的预存失败（11 个文件，28 个失败）
+
+| 测试文件 | 失败数 | 原因 | 与本次改动无关？ |
+|----------|--------|------|-----------------|
+| `tests/1_content/utils/contextExtractorV2.test.ts` | 21 | DOM Range API 在 node 环境下无法工作（jsdom 未配置） | ✅ 无关 |
+| `tests/1_content/utils/rangeAdjuster.test.ts` | 5 | 同上，DOM Range API 问题 | ✅ 无关 |
+| `tests/1_content/utils/audioUtils.test.ts` | suite fail | `@/1_content/utils/audioUtils` 模块不存在 | ✅ 无关 |
+| `tests/1_content/utils/rangeSplitter.test.ts` | suite fail | `@/1_content/utils/rangeSplitter` 模块不存在 | ✅ 无关 |
+| `tests/1_content/utils/selectionValidator.unit.test.ts` | suite fail | `@/1_content/utils/selectionValidator` 模块不存在 | ✅ 无关 |
+| `tests/5_backend/services/AuthService.integration.test.ts` | suite fail | `src/5_backend/config/credentials` 模块不存在（需要 build 时生成） | ✅ 无关 |
+| `tests/5_backend/services/AuthService.simple.test.ts` | suite fail | 同上 | ✅ 无关 |
+| `tests/5_backend/services/ConfigService.simple.test.ts` | suite fail | `other/key/dev/apikey.txt` 不存在（需要本地密钥文件） | ✅ 无关 |
+| `tests/6_translate/services/TranslationService.integration.test.ts` | suite fail | `src/5_backend/config/credentials` 不存在 | ✅ 无关 |
+| `tests/6_translate/services/TranslationService.test.ts` | 1 | `APIError` mock 导出问题（预存 bug） | ✅ 无关 |
+| `tests/7_speech/services/SpeechService.integration.test.ts` | 1 | 认证未配置（需要真实 API 环境） | ✅ 无关 |
+
+**结论：所有 28 个失败均为预存问题，与本次繁体中文支持改动无关。**
+
+---
+
+## 2. 构建检查
+
+### TypeScript 类型检查（`npm run type-check`）
+
+```
+src/2_background/services/ServiceInitializer.ts(9,65): error TS2307: 
+Cannot find module '@/5_backend/config/credentials' or its corresponding type declarations.
+```
+
+**状态：预存错误，与本次改动无关。** `credentials` 模块是 build 时由 `inject-secrets-simple.mjs` 生成的，开发环境中不存在。本次修改的 6 个源文件无类型错误。
+
+### Chrome 构建（`npx vite build`）
+
+```
+Build failed: Could not load src/5_backend/config/credentials
+```
+
+**状态：预存失败，与本次改动无关。** 同样是 `credentials` 模块缺失导致。`npm run build` 还缺少 `inject-secrets-simple.mjs` 脚本文件。
+
+### Firefox 构建
+
+未执行（Chrome 构建已因 credentials 预存问题失败，Firefox 同理）。
+
+**说明：** 构建问题需单独处理（补充 credentials 生成脚本或配置），不阻塞本功能节点的验收。
+
+---
+
+## 3. 验收标准逐项验证
+
+### UI 层
+
+| # | 验收标准 | 状态 | 验证方式 |
+|---|----------|------|----------|
+| 1 | 用户可在 popup 下拉框选择「繁體中文」 | ✅ 通过 | `src/3_popup/index.html` L116 已添加 `<option value="zh-Hant">繁體中文</option>` |
+| 2 | 用户可在 options 页面下拉框选择「繁體中文」 | ✅ 通过 | `src/4_options/index.html` L71 已添加 `<option value="zh-Hant">繁體中文</option>` |
+
+### 引擎层
+
+| # | 验收标准 | 状态 | 说明 |
+|---|----------|------|------|
+| 3 | 翻译结果输出为繁体中文文本 | ⚠️ 未自动化测试 | 需 E2E 手动验证（各引擎实际调用）。引擎层 LANGUAGE_CODE_MAP 已预留映射，代码层面已通路 |
+| 4 | Microsoft Free 引擎正确传递 `zh-Hant` | ✅ 代码就绪 | `LANGUAGE_CODE_MAP` 中 `zh-Hant` → `zh-Hant`（直传），proposal 已确认 |
+| 5 | Google Free 引擎正确映射 `zh-Hant` → `zh-TW` | ✅ 代码就绪 | `LANGUAGE_CODE_MAP` 中 `zh-Hant` → `zh-TW`，proposal 已确认 |
+| 6 | Bing Translate 引擎正确传递 `zh-Hant` | ✅ 代码就绪 | `LANGUAGE_CODE_MAP` 中 `zh-Hant` → `zh-Hant`（直传），proposal 已确认 |
+| 7 | Official Cloud API 正确传递 `zh-Hant` | ⚠️ 待后端确认 | 前端原样透传 `targetLanguage` 字段，后端是否支持需确认。proposal 已标注为中风险 |
+
+### 抑制逻辑
+
+| # | 验收标准 | 状态 | 验证方式 |
+|---|----------|------|----------|
+| 8 | 繁体中文网页在目标 `zh-Hant` 时翻译抑制正常 | ✅ 通过 | `languageValidator.traditional-chinese.test.ts` — zh-TW page + zh-Hant target → suppress (false) ✅ |
+| 9 | 简体中文网页在目标 `zh-Hant` 时不抑制 | ✅ 通过 | 同上 — zh-CN page + zh-Hant target → trigger (true) ✅ |
+| 10 | 繁体中文网页在目标 `zh` 时不抑制 | ✅ 通过 | 同上 — zh-Hant/zh-TW page + zh target → trigger (true) ✅ |
+
+### 存储与显示
+
+| # | 验收标准 | 状态 | 验证方式 |
+|---|----------|------|----------|
+| 11 | `SUPPORTED_LANGUAGES` 包含 `zh-Hant` | ✅ 通过 | `storageManager.ts` 已添加。`traditional-chinese-support.test.ts` — zh-Hant browser → zh-Hant target ✅ |
+| 12 | `LANGUAGE_NAME_MAP` 包含 `zh-Hant` → `"繁體中文"` | ✅ 通过 | `languageDisplay.ts` 已添加 `"zh-hant": "繁體中文"` |
+| 13 | `detectBrowserLanguage` 精确匹配 zh-TW/zh-HK/zh-Hant | ✅ 通过 | 测试 3/3 GREEN：zh-TW → zh-Hant, zh-HK → zh-Hant, zh-Hant → zh-Hant |
+
+### 回归
+
+| # | 验收标准 | 状态 | 验证方式 |
+|---|----------|------|----------|
+| 14 | 简体中文（`zh`）及其他 7 种现有语言不受影响 | ✅ 通过 | `languageValidator.unit.test.ts` 28/28 GREEN（含 1 个适配：xmlLang zh-TW → zh-CN）；`traditional-chinese-support.test.ts` 回归测试 3/3 GREEN |
+| 15 | 所有现有测试通过 | ✅ 通过（本次相关） | 本次改动涉及的 3 个测试文件 54/54 passed。预存失败 28 个均与本次改动无关（见第 1 节） |
+
+### i18n
+
+| # | 验收标准 | 状态 | 说明 |
+|---|----------|------|------|
+| 16 | i18n locale 文件已检查并更新 | ✅ 无需改动 | 8 个 locale 文件中无目标语言名称相关的 i18n key。`popup.targetLanguage.label` 是通用的「Translate to」标签，不需要按语言区分。语言名称通过 `LANGUAGE_NAME_MAP` 和 `Intl.DisplayNames` 处理 |
+
+### 构建
+
+| # | 验收标准 | 状态 | 说明 |
+|---|----------|------|------|
+| 17 | Chrome 构建成功 | ❌ 预存失败 | `credentials` 模块缺失，与本次改动无关 |
+| 18 | Firefox 构建成功 | ❌ 预存失败 | 同上 |
+| 19 | TypeScript 类型检查通过 | ⚠️ 预存错误 | `credentials` 模块缺失，与本次改动无关。本次修改的 6 个源文件无新增类型错误 |
+
+### Custom LLM（proposal 标注的可选项）
+
+| # | 项目 | 状态 | 说明 |
+|---|------|------|------|
+| 20 | `promptLoader.ts` zh-Hant 处理 | ⚠️ 未修改 | L102 `split("-")[0]` 会将 `zh-Hant` 截断为 `zh`。proposal 建议修改但标注为「可能需要修改」。需求文档明确「不修改 Custom LLM 引擎的繁简区分逻辑（本次仅确保免费引擎链路通畅）」，故不阻塞 |
+
+---
+
+## 4. 预存问题说明
+
+以下问题在本次改动之前就已存在，不影响本次功能验收：
+
+1. **`src/5_backend/config/credentials` 模块缺失**：build 时由 `inject-secrets-simple.mjs` 生成，开发环境缺失。导致 5 个测试 suite 失败 + type-check 1 个错误 + build 失败。
+2. **`other/key/dev/apikey.txt` 缺失**：本地开发密钥文件。导致 `ConfigService.simple.test.ts` 失败。
+3. **DOM Range 测试失败**（`contextExtractorV2`、`rangeAdjuster`）：26 个测试因 vitest 默认 node 环境缺少完整 DOM Range API 而失败。需要配置 jsdom 环境或运行在浏览器环境中。
+4. **3 个模块不存在**（`audioUtils`、`rangeSplitter`、`selectionValidator`）：可能是尚未实现的模块或已重命名。
+5. **`TranslationService.test.ts` APIError mock 问题**：mock 配置缺少 `APIError` 导出。
+
+---
+
+## 5. 未修改但 proposal 提到的文件
+
+| 文件 | proposal 建议 | 实际处理 | 原因 |
+|------|--------------|----------|------|
+| `src/8_generate/utils/promptLoader.ts` | L102 `split("-")[0]` 增加 zh-Hant 特判 | ❌ 未修改 | requirement.md 明确排除：「不修改 Custom LLM 引擎的繁简区分逻辑（本次仅确保免费引擎链路通畅）」|
+| `src/0_common/locales/*.json` | 补充 i18n key | ❌ 无需修改 | 检查后确认无目标语言名称相关的 i18n key |
+| `src/1_content/utils/languageDetector.ts` L129 | proposal 分析后认为无需修改 | ❌ 未修改 | proposal 已说明：「其输出会被 `isSameLanguage` 正确处理」|
+
+---
+
+## 6. 建议的后续 E2E 手动验证
+
+以下场景需要真实浏览器环境验证：
+
+1. 打开知乎（zh-CN 页面），目标设为繁体，划词翻译 → 确认翻译功能正常触发且结果为繁体
+2. 打开苹果台湾官网（zh-TW 页面），目标设为繁体 → 确认翻译被正确抑制
+3. 打开 BBC 英文站，目标设为繁体 → 确认翻译正常且结果为繁体
+4. popup 和 options 下拉列表可见「繁體中文」选项，选中后正确保存
+5. 分别使用 Microsoft Free、Google Free、Bing Translate、MTranServer 验证繁体翻译

--- a/src/0_common/utils/languageDisplay.ts
+++ b/src/0_common/utils/languageDisplay.ts
@@ -9,6 +9,7 @@ const DEFAULT_FALLBACK_LOCALE = "en"
 const LANGUAGE_NAME_MAP: Record<string, string> = {
     en: "English",
     zh: "中文",
+    "zh-hant": "繁體中文",
     es: "Español",
     ja: "日本語",
     fr: "Français",

--- a/src/0_common/utils/languageTagUtils.ts
+++ b/src/0_common/utils/languageTagUtils.ts
@@ -1,0 +1,51 @@
+/**
+ * Language Tag Utilities
+ *
+ * Shared functions for BCP 47 language tag normalization and comparison.
+ * Used by languageValidator.ts (selection-based suppression) and
+ * pageLanguageChecker.ts (page-level floating button suppression).
+ */
+
+/** Normalize a language tag: lowercase, replace underscores with hyphens, preserve full BCP 47 tag. */
+export function normalizeLanguageTagFull(tag: string | null | undefined): string {
+    if (!tag) return ""
+    return tag.trim().toLowerCase().replace(/_/g, "-")
+}
+
+/** Normalize locale metadata from og:locale or content-language: first token, hyphens. */
+export function normalizeLocaleMeta(content: string | null | undefined): string {
+    if (!content) return ""
+    const firstToken = content.split(",")[0]?.trim().toLowerCase() ?? ""
+    if (!firstToken) return ""
+    return firstToken.replace(/_/g, "-")
+}
+
+/** Check if a language tag represents Traditional Chinese. */
+export function isTraditionalChinese(lang: string): boolean {
+    const lower = lang.toLowerCase()
+    return lower.includes("hant") || lower.includes("tw") || lower.includes("hk") || lower.includes("mo")
+}
+
+/** Extract the primary language subtag (before the first hyphen). */
+export function getMainSubtag(lang: string): string {
+    return lang.split("-")[0]?.trim().toLowerCase() ?? ""
+}
+
+/**
+ * Compare two language tags to decide if they represent the same language.
+ * For zh-* languages, differentiate between Simplified and Traditional.
+ * For other languages, only compare the primary subtag.
+ */
+export function isSameLanguage(pageLang: string, targetLang: string): boolean {
+    const normalizedPage = normalizeLanguageTagFull(pageLang)
+    const normalizedTarget = normalizeLanguageTagFull(targetLang)
+    if (normalizedPage === normalizedTarget) return true
+
+    const pageMain = getMainSubtag(normalizedPage)
+    const targetMain = getMainSubtag(normalizedTarget)
+
+    if (pageMain === "zh" && targetMain === "zh") {
+        return isTraditionalChinese(normalizedPage) === isTraditionalChinese(normalizedTarget)
+    }
+    return pageMain === targetMain
+}

--- a/src/0_common/utils/storageManager.ts
+++ b/src/0_common/utils/storageManager.ts
@@ -241,11 +241,18 @@ export async function getUserSettings(): Promise<types.UserSettings> {
  * @returns Language code for target language
  */
 function detectBrowserLanguage(): string {
-    const SUPPORTED_LANGUAGES = ["en", "zh", "es", "ja", "fr", "de", "ko", "ru"]
+    const SUPPORTED_LANGUAGES = ["en", "zh", "zh-Hant", "es", "ja", "fr", "de", "ko", "ru"]
 
     // Get browser language (e.g., "zh-CN", "en-US", "ja")
     // Use optional chaining and nullish coalescing for safe access
     const browserLang = navigator.language || navigator.languages?.[0] || "en"
+
+    // Precise match for Traditional Chinese browser languages before split fallback
+    const lowerBrowserLang = browserLang.toLowerCase()
+    if (lowerBrowserLang === "zh-tw" || lowerBrowserLang === "zh-hk" || lowerBrowserLang === "zh-hant") {
+        logger.info("Browser language matched Traditional Chinese:", browserLang)
+        return "zh-Hant"
+    }
 
     // Extract primary language code (before hyphen)
     const parts = browserLang.split("-")

--- a/src/0_common/utils/storageManager.ts
+++ b/src/0_common/utils/storageManager.ts
@@ -249,7 +249,7 @@ function detectBrowserLanguage(): string {
 
     // Precise match for Traditional Chinese browser languages before split fallback
     const lowerBrowserLang = browserLang.toLowerCase()
-    if (lowerBrowserLang === "zh-tw" || lowerBrowserLang === "zh-hk" || lowerBrowserLang === "zh-hant") {
+    if (lowerBrowserLang === "zh-tw" || lowerBrowserLang === "zh-hk" || lowerBrowserLang === "zh-mo" || lowerBrowserLang === "zh-hant") {
         logger.info("Browser language matched Traditional Chinese:", browserLang)
         return "zh-Hant"
     }

--- a/src/11_full_translate/dom/translationWalker.ts
+++ b/src/11_full_translate/dom/translationWalker.ts
@@ -130,10 +130,23 @@ export function shouldTranslateParagraph(
  * Chinese-target optimization for full-page translation.
  * Skips blocks that are already clearly Chinese, while mixed-language blocks
  * still go to the backend so the model can translate the non-Chinese parts.
+ *
+ * For zh-Hant target: only skip text that is already Traditional Chinese.
+ * Simplified or script-neutral text should still be translated (simp→trad).
  */
 function shouldSkipChineseTargetLanguageText(text: string, targetLanguage?: string): boolean {
     const normalizedTarget = (targetLanguage || '').toLowerCase().split(/[-_]/)[0] ?? '';
     if (normalizedTarget !== CHINESE_TARGET_LANG) return false;
+
+    // For Traditional Chinese target, don't skip text that might be Simplified.
+    // The full-page translator should handle both directions (simp→trad and trad→simp).
+    // Only skip text that is clearly already in the target script.
+    // For now, keep the original behavior for plain "zh" target,
+    // but for "zh-Hant", only skip if the text contains Traditional characters.
+    const fullTarget = (targetLanguage || '').toLowerCase();
+    const isTraditionalTarget = fullTarget.includes('hant') ||
+                                fullTarget.includes('tw') ||
+                                fullTarget.includes('hk');
 
     const trimmed = text.trim();
     if (!trimmed) return false;
@@ -142,6 +155,16 @@ function shouldSkipChineseTargetLanguageText(text: string, targetLanguage?: stri
     const hanCount = trimmed.match(REGEX_HAN)?.length ?? 0;
     if (hanCount < CHINESE_TARGET_MIN_HAN_COUNT) return false;
 
+    // For zh-Hant target: only skip if text is already Traditional
+    if (isTraditionalTarget) {
+        // Check if text contains any Traditional-only characters
+        const hasTraditional = checkHasTraditionalChars(trimmed);
+        if (hasTraditional) return true;  // Already traditional, skip
+        // Text is simplified or neutral — don't skip, needs translation
+        return false;
+    }
+
+    // For plain zh target: original behavior
     const latinCount = trimmed.match(REGEX_LATIN)?.length ?? 0;
     if (latinCount === 0) return true;
 
@@ -149,6 +172,16 @@ function shouldSkipChineseTargetLanguageText(text: string, targetLanguage?: stri
     const hanRatio = comparableCount === 0 ? 0 : hanCount / comparableCount;
     return hanCount >= CHINESE_TARGET_DOMINANT_MIN_HAN_COUNT
         && hanRatio >= CHINESE_TARGET_DOMINANT_HAN_RATIO;
+}
+
+// Traditional Chinese indicator characters (subset for quick check)
+const TRADITIONAL_INDICATOR_CHARS = new Set("愛礙罷備筆畢邊變標佈測廠場暢車陳塵遲醜從達帶單當黨導敵電釣東動獨頓發罰煩訪費廢奮複負蓋幹剛綱個給宮貢構購穀顧僱掛廣歸龜貴國號轟鴻後護劃懷壞歡還匯會渾獲貨禍擊機積飢膚雞級幾計記際劑濟夾鉀價駕堅鉛儉劍漸礁膠腳較節莖驚經頸競舊劇據鋸覺決殼塊寬礦曠況虧來賴藍攔欄覽勞澇樂離禮歷勵隸連憐蓮聯鐮倆糧兩遼裂獵臨鄰靈領嶺劉陸錄慮論腦鬧釀鳥農盤龐賠噴騙貧評撲鋪樸氣遷僑橋竊欽親輕慶區權勸熱認灑傘喪掃澀殺曬閃陝賞燒設審聲勝聖詩時識實適釋壽書術樹雙誰絲鬆蘇雖隨歲損鎖態嘆討騰體塗團脫馱彎萬網衛穩務烏無膽鐘轉壯狀齊維穢濁興譽軒選學醫郵魚圓緣遠雲雜災髒戰張趙鎮爭鄭證織職執質滯種眾軸駐專莊裝髮準濟".split(""))
+
+function checkHasTraditionalChars(text: string): boolean {
+    for (const char of text) {
+        if (TRADITIONAL_INDICATOR_CHARS.has(char)) return true
+    }
+    return false
 }
 
 /** Flush accumulated inline nodes into a TranslationUnit if they have text content */

--- a/src/1_content/utils/languageValidator.ts
+++ b/src/1_content/utils/languageValidator.ts
@@ -6,6 +6,12 @@
  */
 import * as loggerModule from "@/0_common/utils/logger"
 import { detectSourceLanguageAsync } from "@/1_content/utils/languageDetector"
+import {
+    normalizeLanguageTagFull,
+    normalizeLocaleMeta,
+    getMainSubtag,
+    isSameLanguage,
+} from "@/0_common/utils/languageTagUtils"
 
 const logger = loggerModule.createLogger("languageValidator")
 
@@ -15,12 +21,12 @@ const CONTEXT_CHINESE_RATIO_THRESHOLD = 0.10
 function getPageDeclaredLanguage(): string {
     if (typeof document === "undefined") return ""
 
-    const htmlLang = normalizeLanguageTag(document.documentElement.lang)
+    const htmlLang = normalizeLanguageTagFull(document.documentElement.lang)
     if (htmlLang) {
         return htmlLang
     }
 
-    const xmlLang = normalizeLanguageTag(document.documentElement.getAttribute("xml:lang"))
+    const xmlLang = normalizeLanguageTagFull(document.documentElement.getAttribute("xml:lang"))
     if (xmlLang) {
         return xmlLang
     }
@@ -28,8 +34,9 @@ function getPageDeclaredLanguage(): string {
     const ogLocale = normalizeLocaleMeta(document.querySelector('meta[property="og:locale"]')?.getAttribute("content"))
     const contentLanguage = normalizeLocaleMeta(document.querySelector('meta[http-equiv="content-language"]')?.getAttribute("content"))
 
-    if (ogLocale && contentLanguage && ogLocale === contentLanguage) {
-        return ogLocale
+    if (ogLocale && contentLanguage) {
+        // Only trust meta tags when they agree; conflicting signals are unreliable
+        return ogLocale === contentLanguage ? ogLocale : ""
     }
 
     return ogLocale || contentLanguage || ""
@@ -49,6 +56,7 @@ const REGEX_LATIN = /\p{Script=Latin}/gu
  * - If text matches the target language's native script, we assume the user is a native speaker reading their own language
  *   and does not need translation.
  * - For Chinese ('zh'), we use a ratio check because Han characters are shared with Japanese.
+ *   For zh-Hant (Traditional Chinese), we differentiate between Simplified and Traditional script.
  * - For Japanese ('ja'), we check for Kana (Hiragana/Katakana) which are unique to Japanese.
  * - For Korean ('ko') and Russian ('ru'), we check for their specific scripts.
  * - For all languages, we also check the page's `<html lang="...">` metadata as a fast, reliable signal.
@@ -61,17 +69,31 @@ const REGEX_LATIN = /\p{Script=Latin}/gu
  * @returns true if translation should be triggered, false if it should be suppressed
  */
 export async function shouldTriggerTranslationAsync(text: string, targetLanguage: string, contextText?: string): Promise<boolean> {
-    const tgtLang = (targetLanguage || "").toLowerCase().split("-")[0] // Normalize 'zh-CN' -> 'zh'
+    const tgtLang = (targetLanguage || "").toLowerCase() // Only lowercase, do NOT split
     const pageDeclaredLanguage = getPageDeclaredLanguage()
 
-    switch (tgtLang) {
+    // Determine the primary language subtag for switch dispatch
+    const tgtMain = getMainSubtag(tgtLang)
+
+    switch (tgtMain) {
         case "zh": {
-            // 1. Check if the selection ITSELF is Chinese
-            // Check for Han characters ratio, but allow if Japanese Kana is present
+            // 1. Check for Japanese Kana first
             if (REGEX_KANA.test(text)) {
                 return true // It's likely Japanese, so show translation for Chinese user
             }
-            // Count Han characters
+
+            // 2. Check page's declared language FIRST (before text analysis)
+            // This handles the case where the page declares zh-TW/zh-Hant and target is zh-Hant,
+            // even if the selected text itself is script-neutral (e.g., "你好世界").
+            if (pageDeclaredLanguage && isSameLanguage(pageDeclaredLanguage, tgtLang)) {
+                logger.debug("Suppressing translation: page metadata declares same Chinese variant", {
+                    pageDeclaredLanguage,
+                    tgtLang,
+                })
+                return false
+            }
+
+            // 3. Check if the selection ITSELF is Chinese
             const chineseMatches = text.match(REGEX_HAN)
             const chineseCount = chineseMatches ? chineseMatches.length : 0
             const totalLength = text.length
@@ -84,23 +106,28 @@ export async function shouldTriggerTranslationAsync(text: string, targetLanguage
                     logger.debug("Allowing translation: Han ratio high but context has Kana → Japanese page")
                     return true
                 }
-                logger.debug("Suppressing translation: Target is Chinese and text is identified as Chinese", {
+                // Detect the script variant of the selected text to differentiate Simplified vs Traditional
+                const textScript = detectChineseScript(text)
+                const textLang = textScript === "traditional" ? "zh-Hant" : "zh"
+                if (isSameLanguage(textLang, tgtLang)) {
+                    logger.debug("Suppressing translation: Target matches text language (same Chinese variant)", {
+                        text: text.substring(0, 20) + "...",
+                        ratio: chineseCount / totalLength,
+                        textScript,
+                        tgtLang,
+                    })
+                    return false
+                }
+                // Text is Chinese but different script variant from target
+                logger.debug("Allowing translation: Chinese text but different script variant", {
                     text: text.substring(0, 20) + "...",
-                    ratio: chineseCount / totalLength,
+                    textScript,
+                    tgtLang,
                 })
-                return false
+                return true
             }
 
-            // 2. Check page's declared language (fast, synchronous, reliable when set)
-            // Covers cases where the selected text is pure Latin but the page is Chinese.
-            if (pageDeclaredLanguage === "zh") {
-                logger.debug("Suppressing translation: Target is Chinese and page metadata declares Chinese", {
-                    pageDeclaredLanguage,
-                })
-                return false
-            }
-
-            // 3. Check whether the surrounding context is Chinese-dominant.
+            // 4. Check whether the surrounding context is Chinese-dominant.
             // A few Chinese characters (e.g. a translated link title on an otherwise English page)
             // should not suppress translation. Require a meaningful Han ratio instead.
             // Guard: if context contains Japanese Kana, it is a Japanese page — don't suppress.
@@ -114,11 +141,17 @@ export async function shouldTriggerTranslationAsync(text: string, targetLanguage
                     threshold: CONTEXT_CHINESE_RATIO_THRESHOLD,
                 })
                 if (contextChineseRatio >= CONTEXT_CHINESE_RATIO_THRESHOLD) {
-                    logger.debug("Suppressing translation: Target is Chinese and context is Chinese-dominant", {
-                        contextSnippet: contextText.substring(0, 20) + "...",
-                        ratio: contextChineseRatio,
-                    })
-                    return false
+                    // Detect script of context text to differentiate Simplified vs Traditional
+                    const contextScript = detectChineseScript(contextText)
+                    const contextLang = contextScript === "traditional" ? "zh-Hant" : "zh"
+                    if (isSameLanguage(contextLang, tgtLang)) {
+                        logger.debug("Suppressing translation: Target is Chinese and context is Chinese-dominant (same variant)", {
+                            contextSnippet: contextText.substring(0, 20) + "...",
+                            ratio: contextChineseRatio,
+                            contextScript,
+                        })
+                        return false
+                    }
                 }
             }
 
@@ -159,15 +192,15 @@ export async function shouldTriggerTranslationAsync(text: string, targetLanguage
         default: {
             // Other languages (es, fr, de, etc.)
             // Fast-path: check page's declared language before async detection
-            if (getPageDeclaredLanguage() === tgtLang) {
-                logger.debug(`Suppressing translation: Target is ${tgtLang} and page declares it via lang attribute`)
+            if (pageDeclaredLanguage && isSameLanguage(pageDeclaredLanguage, tgtLang)) {
+                logger.debug(`Suppressing translation: Target is ${tgtMain} and page declares it via lang attribute`)
                 return false
             }
             // Fallback: rely on async language detection if context is provided
             if (contextText && contextText.length > 0) {
                 const { lang: detectedLang } = await detectSourceLanguageAsync(contextText)
-                if (detectedLang === tgtLang) {
-                    logger.debug(`Suppressing translation: Target is ${tgtLang} and context detected as ${detectedLang}`)
+                if (detectedLang === tgtMain) {
+                    logger.debug(`Suppressing translation: Target is ${tgtMain} and context detected as ${detectedLang}`)
                     return false
                 }
             }
@@ -187,16 +220,29 @@ function calculateHanRatioAgainstHanAndLatin(text: string): number {
     return hanCount / comparableCount
 }
 
-function normalizeLanguageTag(tag: string | null | undefined): string {
-    if (!tag) return ""
-    return tag.toLowerCase().split("-")[0]?.trim() ?? ""
-}
+/**
+ * A set of characters that only appear in Traditional Chinese (not in Simplified).
+ * Used as a heuristic to detect if Chinese text is traditional or simplified.
+ * Not exhaustive but covers the most common discriminating characters.
+ */
+const TRADITIONAL_ONLY_CHARS = new Set(
+    ("愛礙罷備筆畢邊變標佈測廠場暢車陳塵遲醜從達帶單當黨導敵電釣東動獨頓發罰煩訪費廢奮複負蓋幹剛綱個給宮貢構購穀顧僱掛廣歸龜貴國號轟鴻後護劃懷壞歡還匯會渾獲貨禍擊機積飢膚雞級幾計記際劑濟夾鉀價駕堅鉛儉劍漸礁膠腳較節莖驚經頸競舊劇據鋸覺決殼塊寬礦曠況虧來賴藍攔欄覽勞澇樂離禮歷勵隸連憐蓮聯鐮倆糧兩遼裂獵臨鄰靈領嶺劉陸錄慮論腦鬧釀鳥農盤龐賠噴騙貧評撲鋪樸氣遷僑橋竊欽親輕慶區權勸熱認灑傘喪掃澀殺曬閃陝賞燒設審聲勝聖詩時識實適釋壽書術樹雙誰絲鬆蘇雖隨歲損鎖態嘆討騰體塗團脫馱彎萬網衛穩務烏無膽鐘轉壯狀齊維穢濁興譽軒選學醫郵魚圓緣遠雲雜災髒戰張趙鎮爭鄭證織職執質滯種眾軸駐專莊裝髮準濟").split("")
+)
 
-function normalizeLocaleMeta(content: string | null | undefined): string {
-    if (!content) return ""
-
-    const firstToken = content.split(",")[0]?.trim().toLowerCase() ?? ""
-    if (!firstToken) return ""
-
-    return firstToken.split(/[-_]/)[0]?.trim() ?? ""
+/**
+ * Detect whether Chinese text uses Traditional or Simplified characters.
+ * Uses a heuristic: if any character in the text is a known Traditional-only character,
+ * the text is classified as Traditional.
+ *
+ * @param text - Chinese text to analyze
+ * @returns "traditional", "simplified", or "unknown" (empty/no Han chars)
+ */
+function detectChineseScript(text: string): "traditional" | "simplified" | "unknown" {
+    if (!text) return "unknown"
+    for (const char of text) {
+        if (TRADITIONAL_ONLY_CHARS.has(char)) {
+            return "traditional"
+        }
+    }
+    return "simplified"
 }

--- a/src/1_content/utils/pageLanguageChecker.ts
+++ b/src/1_content/utils/pageLanguageChecker.ts
@@ -5,6 +5,11 @@
  */
 
 import * as loggerModule from '@/0_common/utils/logger';
+import {
+    normalizeLanguageTagFull as normalizeLangTag,
+    normalizeLocaleMeta,
+    isSameLanguage,
+} from '@/0_common/utils/languageTagUtils';
 
 const logger = loggerModule.createLogger('pageLanguageChecker');
 
@@ -20,7 +25,7 @@ const REGEX_CYRILLIC = /\p{Script=Cyrillic}/u;
 
 /**
  * Detect the page's declared language from HTML metadata.
- * Returns a normalized base language code (e.g., "zh", "en", "ja").
+ * Returns a normalized full language code preserving subtags (e.g., "zh-cn", "zh-tw", "en", "ja").
  */
 function getPageDeclaredLanguage(): string {
     if (typeof document === 'undefined') return '';
@@ -31,12 +36,17 @@ function getPageDeclaredLanguage(): string {
     const xmlLang = normalizeLangTag(document.documentElement.getAttribute('xml:lang'));
     if (xmlLang) return xmlLang;
 
-    const ogLocale = normalizeLangTag(
+    const ogLocale = normalizeLocaleMeta(
         document.querySelector('meta[property="og:locale"]')?.getAttribute('content')
     );
-    const contentLanguage = normalizeLangTag(
+    const contentLanguage = normalizeLocaleMeta(
         document.querySelector('meta[http-equiv="content-language"]')?.getAttribute('content')
     );
+
+    // Only trust meta tags when they agree; conflicting signals are unreliable
+    if (ogLocale && contentLanguage) {
+        return ogLocale === contentLanguage ? ogLocale : '';
+    }
 
     return ogLocale || contentLanguage || '';
 }
@@ -78,17 +88,17 @@ function detectLanguageFromContent(): string {
  * 1. HTML metadata (lang attribute, og:locale, content-language meta)
  * 2. Script-based content sampling (for CJK and Cyrillic scripts)
  *
- * @param targetLanguage - User's target translation language (e.g., "zh", "ja", "en")
+ * @param targetLanguage - User's target translation language (e.g., "zh", "zh-Hant", "ja", "en")
  * @returns true if the page appears to be in the target language
  */
 export function isPageLanguageSameAsTarget(targetLanguage: string): boolean {
-    const tgt = targetLanguage.toLowerCase().split('-')[0] ?? '';
+    const tgt = (targetLanguage || '').toLowerCase();
     if (!tgt) return false;
 
     // Signal 1: declared language from metadata
     const declared = getPageDeclaredLanguage();
     if (declared) {
-        const match = declared === tgt;
+        const match = isSameLanguage(declared, tgt);
         logger.debug(`Page declared language: "${declared}", target: "${tgt}", match: ${match}`);
         return match;
     }
@@ -96,16 +106,11 @@ export function isPageLanguageSameAsTarget(targetLanguage: string): boolean {
     // Signal 2: script-based content sampling
     const detected = detectLanguageFromContent();
     if (detected) {
-        const match = detected === tgt;
+        const match = isSameLanguage(detected, tgt);
         logger.debug(`Page detected language (content sampling): "${detected}", target: "${tgt}", match: ${match}`);
         return match;
     }
 
     logger.debug(`Page language undetermined, assuming not same as target: "${tgt}"`);
     return false;
-}
-
-function normalizeLangTag(tag: string | null | undefined): string {
-    if (!tag) return '';
-    return tag.toLowerCase().split(/[-_]/)[0]?.trim() ?? '';
 }

--- a/src/3_popup/index.html
+++ b/src/3_popup/index.html
@@ -113,6 +113,7 @@
                 <select id="targetLanguage" data-setting="targetLanguage" class="language-select">
                   <option value="en">English</option>
                   <option value="zh">中文</option>
+                  <option value="zh-Hant">繁體中文</option>
                   <option value="es">Español</option>
                   <option value="ja">日本語</option>
                   <option value="fr">Français</option>

--- a/src/4_options/index.html
+++ b/src/4_options/index.html
@@ -68,6 +68,7 @@
                 <select id="targetLanguage" data-setting="targetLanguage" class="select-input">
                   <option value="en">English</option>
                   <option value="zh">中文</option>
+                  <option value="zh-Hant">繁體中文</option>
                   <option value="es">Español</option>
                   <option value="ja">日本語</option>
                   <option value="fr">Français</option>

--- a/tests/0_common/utils/traditional-chinese-support.test.ts
+++ b/tests/0_common/utils/traditional-chinese-support.test.ts
@@ -102,6 +102,17 @@ describe("Traditional Chinese Support — Storage and Display", () => {
             const settings = await getUserSettings()
             expect(settings.targetLanguage).toBe("zh-Hant")
         })
+
+        it("navigator.language = 'zh-MO' → targetLanguage = 'zh-Hant'", async () => {
+            // zh-MO (Macau) uses Traditional Chinese; requirement background explicitly mentions Macau users.
+            vi.stubGlobal("navigator", {
+                language: "zh-MO",
+                languages: ["zh-MO", "zh", "en"],
+            })
+
+            const settings = await getUserSettings()
+            expect(settings.targetLanguage).toBe("zh-Hant")
+        })
     })
 
     describe("detectBrowserLanguage — regression for existing languages", () => {

--- a/tests/0_common/utils/traditional-chinese-support.test.ts
+++ b/tests/0_common/utils/traditional-chinese-support.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Traditional Chinese Support — TDD Tests for Storage and Display Layers
+ *
+ * Tests:
+ * - detectBrowserLanguage should map zh-TW/zh-HK/zh-Hant browsers to zh-Hant
+ * - SUPPORTED_LANGUAGES should include zh-Hant (indirect via detectBrowserLanguage)
+ * - LANGUAGE_NAME_MAP should include zh-Hant → "繁體中文" (via getLanguageDisplayName)
+ *
+ * Expected: Feature-specific tests FAIL (red) until implementation.
+ * Regression tests for existing languages should PASS (green).
+ *
+ * Proposal: docs/plan/y2026/month06/m06-traditional-chinese-support/proposal.md
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
+
+// Mock platformDetector to avoid chrome.runtime.getPlatformInfo calls.
+// storageManager imports getPlatformOS and PLATFORMS from this module.
+vi.mock("@/0_common/utils/platformDetector", () => ({
+    getPlatformOS: vi.fn().mockResolvedValue("mac"),
+    PLATFORMS: { MAC: "mac", WIN: "windows", LINUX: "linux", OTHER: "other" },
+}))
+
+import { getUserSettings } from "@/0_common/utils/storageManager"
+import { getLanguageDisplayName } from "@/0_common/utils/languageDisplay"
+
+describe("Traditional Chinese Support — Storage and Display", () => {
+    // ================================================================
+    // Chrome API mock setup
+    // ================================================================
+    let mockChromeStorageGet: ReturnType<typeof vi.fn>
+    let mockChromeStorageSet: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+        // Default: no stored settings (simulates new user)
+        mockChromeStorageGet = vi.fn((_key: string, callback: (result: any) => void) => {
+            callback({})
+        })
+        mockChromeStorageSet = vi.fn((_data: any, callback: () => void) => {
+            if (callback) callback()
+        })
+
+        global.chrome = {
+            storage: {
+                sync: {
+                    get: mockChromeStorageGet,
+                    set: mockChromeStorageSet,
+                },
+                local: {
+                    get: vi.fn(),
+                    set: vi.fn(),
+                },
+            },
+            runtime: {
+                lastError: undefined as any,
+            },
+        } as any
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+    })
+
+    // ================================================================
+    // detectBrowserLanguage — indirect tests via getUserSettings()
+    // detectBrowserLanguage is private; we observe its effect on the
+    // targetLanguage field of a new user's settings.
+    // ================================================================
+    describe("detectBrowserLanguage — zh-TW/zh-HK/zh-Hant browser → zh-Hant target", () => {
+        it("navigator.language = 'zh-TW' → targetLanguage = 'zh-Hant'", async () => {
+            // RED: Currently detectBrowserLanguage does split("-")[0] → "zh" (simplified).
+            // After fix: precise match for zh-TW → "zh-Hant".
+            vi.stubGlobal("navigator", {
+                language: "zh-TW",
+                languages: ["zh-TW", "zh", "en"],
+            })
+
+            const settings = await getUserSettings()
+            expect(settings.targetLanguage).toBe("zh-Hant")
+        })
+
+        it("navigator.language = 'zh-HK' → targetLanguage = 'zh-Hant'", async () => {
+            // RED: Currently detectBrowserLanguage does split("-")[0] → "zh" (simplified).
+            // After fix: precise match for zh-HK → "zh-Hant".
+            vi.stubGlobal("navigator", {
+                language: "zh-HK",
+                languages: ["zh-HK", "zh", "en"],
+            })
+
+            const settings = await getUserSettings()
+            expect(settings.targetLanguage).toBe("zh-Hant")
+        })
+
+        it("navigator.language = 'zh-Hant' → targetLanguage = 'zh-Hant'", async () => {
+            // RED: Currently "zh-Hant".split("-")[0] → "zh", which is in SUPPORTED_LANGUAGES.
+            // After fix: "zh-Hant" should be in SUPPORTED_LANGUAGES and matched directly.
+            vi.stubGlobal("navigator", {
+                language: "zh-Hant",
+                languages: ["zh-Hant", "zh", "en"],
+            })
+
+            const settings = await getUserSettings()
+            expect(settings.targetLanguage).toBe("zh-Hant")
+        })
+    })
+
+    describe("detectBrowserLanguage — regression for existing languages", () => {
+        it("navigator.language = 'zh-CN' → targetLanguage = 'zh' (regression)", async () => {
+            vi.stubGlobal("navigator", {
+                language: "zh-CN",
+                languages: ["zh-CN", "zh", "en"],
+            })
+
+            const settings = await getUserSettings()
+            expect(settings.targetLanguage).toBe("zh")
+        })
+
+        it("navigator.language = 'en-US' → targetLanguage = 'en' (regression)", async () => {
+            vi.stubGlobal("navigator", {
+                language: "en-US",
+                languages: ["en-US", "en"],
+            })
+
+            const settings = await getUserSettings()
+            expect(settings.targetLanguage).toBe("en")
+        })
+
+        it("navigator.language = 'ja' → targetLanguage = 'ja' (regression)", async () => {
+            vi.stubGlobal("navigator", {
+                language: "ja",
+                languages: ["ja", "en"],
+            })
+
+            const settings = await getUserSettings()
+            expect(settings.targetLanguage).toBe("ja")
+        })
+    })
+
+    // ================================================================
+    // LANGUAGE_NAME_MAP — zh-Hant display name
+    // getLanguageDisplayName tries Intl.DisplayNames first, then falls
+    // back to LANGUAGE_NAME_MAP. These tests verify the overall behavior
+    // is correct for zh-Hant.
+    // ================================================================
+    describe("getLanguageDisplayName — zh-Hant display name", () => {
+        it("getLanguageDisplayName('zh-Hant') should not return raw code", () => {
+            const name = getLanguageDisplayName("zh-Hant")
+            // Should return a human-readable name, not the raw code "zh-Hant"
+            expect(name).not.toBe("zh-Hant")
+        })
+
+        it("getLanguageDisplayName('zh-Hant', 'en') should not return raw code", () => {
+            const name = getLanguageDisplayName("zh-Hant", "en")
+            expect(name).not.toBe("zh-Hant")
+        })
+
+        it("getLanguageDisplayName('zh-Hant', 'zh') should contain Traditional Chinese characters", () => {
+            const name = getLanguageDisplayName("zh-Hant", "zh")
+            // Should contain 繁體 or 繁体 characters
+            expect(name).toMatch(/繁[體体]/)
+        })
+    })
+})

--- a/tests/1_content/utils/languageValidator.traditional-chinese.test.ts
+++ b/tests/1_content/utils/languageValidator.traditional-chinese.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Traditional Chinese Support — TDD Tests for languageValidator
+ *
+ * These tests validate the behavior described in proposal.md (方案 B):
+ * - zh-Hant target language should be differentiated from zh (Simplified)
+ * - Simplified Chinese pages should NOT suppress Traditional Chinese translation
+ * - Traditional Chinese pages SHOULD suppress Traditional Chinese translation
+ * - normalizeLanguageTag should preserve full BCP 47 tags (not truncate to "zh")
+ *
+ * Expected: Feature-specific tests FAIL (red) until implementation is done.
+ * Regression tests for existing languages should PASS (green).
+ *
+ * Proposal: docs/plan/y2026/month06/m06-traditional-chinese-support/proposal.md
+ */
+
+import { shouldTriggerTranslationAsync } from "@/1_content/utils/languageValidator"
+import { describe, expect, it, vi, afterEach } from "vitest"
+
+// Mock languageDetector (same pattern as languageValidator.unit.test.ts)
+vi.mock("@/1_content/utils/languageDetector", () => ({
+    detectSourceLanguageAsync: vi.fn(),
+}))
+
+/**
+ * Stub document language signals for page-level language detection.
+ * Same pattern as existing languageValidator.unit.test.ts
+ */
+function stubDocumentLanguageSignals(options: {
+    htmlLang?: string
+    xmlLang?: string
+    ogLocale?: string
+    contentLanguage?: string
+}) {
+    vi.stubGlobal("document", {
+        documentElement: {
+            lang: options.htmlLang ?? "",
+            getAttribute: (name: string) => (name === "xml:lang" ? options.xmlLang ?? "" : ""),
+        },
+        querySelector: (selector: string) => {
+            if (selector === 'meta[property="og:locale"]' && options.ogLocale) {
+                return {
+                    getAttribute: (name: string) => (name === "content" ? options.ogLocale ?? "" : ""),
+                }
+            }
+            if (selector === 'meta[http-equiv="content-language"]' && options.contentLanguage) {
+                return {
+                    getAttribute: (name: string) => (name === "content" ? options.contentLanguage ?? "" : ""),
+                }
+            }
+            return null
+        },
+    })
+}
+
+describe("Traditional Chinese Support — shouldTriggerTranslationAsync", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals()
+    })
+
+    // ================================================================
+    // 正常路径（should trigger = true）
+    // ================================================================
+    describe("Normal paths — translation should trigger", () => {
+        it("English text with zh-Hant target → true", async () => {
+            // English text should always trigger translation regardless of target language.
+            // This test passes even before the fix (zh-Hant→zh, English text → true).
+            expect(await shouldTriggerTranslationAsync("Hello world", "zh-Hant")).toBe(true)
+        })
+
+        it("Simplified Chinese text with zh-Hant target → true (简繁应区分)", async () => {
+            // RED: Currently zh-Hant → split("-")[0] → "zh", Chinese text detected → suppressed (false)
+            // After fix: Simplified Chinese ≠ Traditional Chinese → should trigger (true)
+            expect(await shouldTriggerTranslationAsync("你好世界", "zh-Hant")).toBe(true)
+        })
+
+        it("Simplified Chinese page (zh-CN) + English selection + zh-Hant target → true", async () => {
+            stubDocumentLanguageSignals({ htmlLang: "zh-CN" })
+            // RED: Currently zh-CN → normalize → "zh", zh-Hant → split → "zh" → match → suppressed (false)
+            // After fix: zh-CN (simplified) ≠ zh-Hant (traditional) → should trigger (true)
+            expect(await shouldTriggerTranslationAsync("iPhone", "zh-Hant")).toBe(true)
+        })
+    })
+
+    // ================================================================
+    // 异常路径（should suppress = false）
+    // ================================================================
+    describe("Suppression paths — translation should NOT trigger", () => {
+        it("Traditional Chinese text with zh-Hant target → false (same language)", async () => {
+            // Text is Traditional Chinese, target is Traditional Chinese → suppress.
+            // Currently passes (both sides truncate to "zh" → Chinese text detected → suppress).
+            // After fix: should still pass (isSameLanguage("zh-Hant", "zh-Hant") → true → suppress).
+            expect(await shouldTriggerTranslationAsync("測試繁體中文", "zh-Hant")).toBe(false)
+        })
+
+        it("Traditional Chinese page (zh-TW) + English selection + zh-Hant target → false", async () => {
+            stubDocumentLanguageSignals({ htmlLang: "zh-TW" })
+            // Page is Traditional Chinese, target is Traditional Chinese → suppress.
+            // Currently passes (both truncate to "zh" → page declares "zh" → suppress).
+            // After fix: should still pass (isSameLanguage("zh-TW", "zh-Hant") → true → suppress).
+            expect(await shouldTriggerTranslationAsync("Release", "zh-Hant")).toBe(false)
+        })
+    })
+
+    // ================================================================
+    // normalizeLanguageTag — preserves full BCP 47 tags
+    // Tested indirectly via getPageDeclaredLanguage behavior
+    // ================================================================
+    describe("normalizeLanguageTag — preserves full BCP 47 tags (indirect)", () => {
+        it("Traditional Chinese page (zh-Hant) + English selection + Simplified target (zh) → true", async () => {
+            stubDocumentLanguageSignals({ htmlLang: "zh-Hant" })
+            // RED: Currently normalizeLanguageTag("zh-Hant") → "zh", matches target "zh" → suppressed (false)
+            // After fix: normalizeLanguageTag("zh-Hant") → "zh-Hant" ≠ "zh" → trigger (true)
+            expect(await shouldTriggerTranslationAsync("Release", "zh")).toBe(true)
+        })
+
+        it("Traditional Chinese page (zh-TW) + English selection + Simplified target (zh) → true", async () => {
+            stubDocumentLanguageSignals({ htmlLang: "zh-TW" })
+            // RED: Currently normalizeLanguageTag("zh-TW") → "zh", matches target "zh" → suppressed (false)
+            // After fix: zh-TW (traditional) ≠ zh (simplified) → trigger (true)
+            expect(await shouldTriggerTranslationAsync("Release", "zh")).toBe(true)
+        })
+    })
+
+    // ================================================================
+    // isSameLanguage — indirect behavioral tests
+    // Validates the Chinese simplified/traditional differentiation logic
+    // ================================================================
+    describe("isSameLanguage logic — indirect behavioral tests", () => {
+        it("zh-CN page + English + zh target → false (same: both simplified)", async () => {
+            stubDocumentLanguageSignals({ htmlLang: "zh-CN" })
+            // Regression: Simplified page + Simplified target → suppress (false)
+            expect(await shouldTriggerTranslationAsync("Release", "zh")).toBe(false)
+        })
+
+        it("zh-TW page + English + zh-Hant target → false (same: both traditional)", async () => {
+            stubDocumentLanguageSignals({ htmlLang: "zh-TW" })
+            // Traditional page + Traditional target → suppress (false)
+            // Currently passes accidentally (both → "zh"), should pass correctly after fix.
+            expect(await shouldTriggerTranslationAsync("Release", "zh-Hant")).toBe(false)
+        })
+
+        it("zh-CN page + English + zh-Hant target → true (different: simplified vs traditional)", async () => {
+            stubDocumentLanguageSignals({ htmlLang: "zh-CN" })
+            // RED: Currently both truncate to "zh" → suppressed (false)
+            // After fix: zh-CN (simplified) ≠ zh-Hant (traditional) → trigger (true)
+            expect(await shouldTriggerTranslationAsync("Release", "zh-Hant")).toBe(true)
+        })
+
+        it("zh-Hans page + English + zh-Hant target → true (different: simplified vs traditional)", async () => {
+            stubDocumentLanguageSignals({ htmlLang: "zh-Hans" })
+            // RED: Currently normalizeLanguageTag("zh-Hans") → "zh", zh-Hant → "zh" → match → suppressed (false)
+            // After fix: zh-Hans (simplified) ≠ zh-Hant (traditional) → trigger (true)
+            expect(await shouldTriggerTranslationAsync("Release", "zh-Hant")).toBe(true)
+        })
+    })
+
+    // ================================================================
+    // isSameLanguage — direct tests (waiting for implementation)
+    // These tests will be enabled after isSameLanguage is exported.
+    // Until then, we test the behavior indirectly via shouldTriggerTranslationAsync above.
+    // ================================================================
+    describe.todo("isSameLanguage (direct unit tests — waiting for export)", () => {
+        // Proposal defines isSameLanguage with the following expected behavior:
+        // - zh-CN vs zh-Hant → false (simplified page ≠ traditional target)
+        // - zh-TW vs zh-Hant → true (traditional page = traditional target)
+        // - zh-Hans vs zh-Hant → false (simplified page ≠ traditional target)
+        // - zh vs zh-Hant → false (bare zh treated as simplified)
+        // - en vs en → true (regression)
+        // - ja vs en → false (regression)
+        // - ko vs ja → false (regression)
+        //
+        // Enable these tests once isSameLanguage is implemented and exported from
+        // languageValidator.ts or a new module.
+        it.todo("zh-CN vs zh-Hant → false")
+        it.todo("zh-TW vs zh-Hant → true")
+        it.todo("zh-Hans vs zh-Hant → false")
+        it.todo("zh vs zh-Hant → false (bare zh treated as simplified)")
+        it.todo("en vs en → true (regression)")
+        it.todo("ja vs en → false (regression)")
+        it.todo("ko vs ja → false (regression)")
+    })
+
+    // ================================================================
+    // 回归验证（确保现有语言不受影响）
+    // ================================================================
+    describe("Regression — existing languages unchanged", () => {
+        it("Simplified Chinese text + zh target → false (suppress)", async () => {
+            expect(await shouldTriggerTranslationAsync("你好世界", "zh")).toBe(false)
+        })
+
+        it("English text + en target → true", async () => {
+            expect(await shouldTriggerTranslationAsync("Hello", "en")).toBe(true)
+        })
+
+        it("Japanese text + ja target → false (suppress)", async () => {
+            expect(await shouldTriggerTranslationAsync("こんにちは", "ja")).toBe(false)
+        })
+
+        it("English text + zh target → true (not Chinese text)", async () => {
+            expect(await shouldTriggerTranslationAsync("Hello world", "zh")).toBe(true)
+        })
+
+        it("Korean text + ko target → false (suppress)", async () => {
+            expect(await shouldTriggerTranslationAsync("안녕하세요", "ko")).toBe(false)
+        })
+
+        it("Russian text + ru target → false (suppress)", async () => {
+            expect(await shouldTriggerTranslationAsync("Привет", "ru")).toBe(false)
+        })
+    })
+})

--- a/tests/1_content/utils/languageValidator.unit.test.ts
+++ b/tests/1_content/utils/languageValidator.unit.test.ts
@@ -120,7 +120,9 @@ describe("shouldTriggerTranslationAsync", () => {
         })
 
         it("uses xml:lang when html lang is missing", async () => {
-            stubDocumentLanguageSignals({ xmlLang: "zh-TW" })
+            // Use zh-CN (simplified) so that isSameLanguage("zh-cn", "zh") → true → suppress.
+            // With zh-TW, the new logic correctly differentiates traditional ≠ simplified → trigger.
+            stubDocumentLanguageSignals({ xmlLang: "zh-CN" })
 
             expect(await shouldTriggerTranslationAsync("Release", "zh")).toBe(false)
             vi.unstubAllGlobals()


### PR DESCRIPTION
## Summary

实现 Issue #23 — 翻译目标语言新增繁体中文 (zh-Hant) 支持。

## Changes

### 核心改动（8 文件修改 + 1 新建）
| 文件 | 改动 |
|------|------|
| `src/0_common/utils/languageTagUtils.ts` | **新建** — 共享语言标签工具模块 |
| `src/0_common/utils/languageDisplay.ts` | 添加 `zh-hant: 繁體中文` 显示名 |
| `src/0_common/utils/storageManager.ts` | `detectBrowserLanguage()` 精确匹配 zh-TW/zh-HK/zh-Hant |
| `src/1_content/utils/languageValidator.ts` | 核心逻辑：`isSameLanguage()` 简繁区分 + `detectChineseScript()` |
| `src/1_content/utils/pageLanguageChecker.ts` | 同步共享模块 + ogLocale/contentLanguage 冲突检查 |
| `src/11_full_translate/dom/translationWalker.ts` | zh-Hant 分支：仅跳过已含繁体字的文本 |
| `src/3_popup/index.html` | 添加 `<option value="zh-Hant">繁體中文</option>` |
| `src/4_options/index.html` | 同上 |

### 测试（2 新建 + 1 修改）
- `tests/0_common/utils/traditional-chinese-support.test.ts` — 新增
- `tests/1_content/utils/languageValidator.traditional-chinese.test.ts` — 新增
- `tests/1_content/utils/languageValidator.unit.test.ts` — 1 个回归测试适配

## Test Results
- ✅ 97 passed | 7 todo
- ⚠️ 28 failed (all pre-existing, unrelated to this PR)

## Code Review
双模型 Review 4 轮，最终双 APPROVED：
- Reviewer A (GPT-5.5): ✅ APPROVED (Round-04)
- Reviewer B (DeepSeek V4 Pro): ✅ APPROVED (Round-04)

Closes #23